### PR TITLE
chore: Reinstate Simplified PoX

### DIFF
--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -73,8 +73,8 @@ impl<'a> SortitionHandleTx<'a> {
         parent_snapshot: &BlockSnapshot,
         block_header: &BurnchainBlockHeader,
         this_block_ops: &Vec<BlockstackOperationType>,
-        _next_pox_info: Option<RewardCycleInfo>,
-        _parent_pox: PoxId,
+        next_pox_info: Option<RewardCycleInfo>,
+        parent_pox: PoxId,
         reward_info: Option<&RewardSetInfo>,
         initial_mining_bonus_ustx: u128,
     ) -> Result<(BlockSnapshot, BurnchainStateTransition), BurnchainError> {
@@ -95,6 +95,15 @@ impl<'a> SortitionHandleTx<'a> {
             .iter()
             .map(|ref op| op.txid())
             .collect();
+
+        let mut next_pox = parent_pox;
+        if let Some(ref next_pox_info) = next_pox_info {
+            debug!(
+                "Assume block is an anchor block={:?}",
+                &next_pox_info.selected_anchor_block()
+            );
+            next_pox.extend_with_present_block();
+        };
 
         // the SortitionId in Hyperchains is always equal to the identifying hash
         // of the L1 block (i.e., the burn block hash)
@@ -164,6 +173,7 @@ impl<'a> SortitionHandleTx<'a> {
             parent_snapshot,
             &snapshot,
             &state_transition.accepted_ops,
+            next_pox_info,
             reward_info,
             initialize_bonus,
         )?;

--- a/src/chainstate/burn/db/tests.rs
+++ b/src/chainstate/burn/db/tests.rs
@@ -113,7 +113,7 @@ pub fn test_append_snapshot(
     sn.consensus_hash = ConsensusHash(Hash160::from_data(&sn.consensus_hash.0).0);
 
     let index_root = tx
-        .append_chain_tip_snapshot(&sn_parent, &sn, block_ops, None, None)
+        .append_chain_tip_snapshot(&sn_parent, &sn, block_ops, None, None, None)
         .unwrap();
     sn.index_root = index_root;
 
@@ -216,7 +216,7 @@ fn test_insert_block_commit() {
         sn.consensus_hash = ConsensusHash([0x23; 20]);
 
         let index_root = tx
-            .append_chain_tip_snapshot(&sn_parent, &sn, &vec![], None, None)
+            .append_chain_tip_snapshot(&sn_parent, &sn, &vec![], None, None, None)
             .unwrap();
         sn.index_root = index_root;
 
@@ -377,7 +377,7 @@ fn is_fresh_consensus_hash() {
                 canonical_stacks_tip_consensus_hash: ConsensusHash([0u8; 20]),
             };
             let index_root = tx
-                .append_chain_tip_snapshot(&last_snapshot, &snapshot_row, &vec![], None, None)
+                .append_chain_tip_snapshot(&last_snapshot, &snapshot_row, &vec![], None, None, None)
                 .unwrap();
             last_snapshot = snapshot_row;
             last_snapshot.index_root = index_root;
@@ -616,7 +616,7 @@ fn get_consensus_at() {
                 canonical_stacks_tip_consensus_hash: ConsensusHash([0u8; 20]),
             };
             let index_root = tx
-                .append_chain_tip_snapshot(&last_snapshot, &snapshot_row, &vec![], None, None)
+                .append_chain_tip_snapshot(&last_snapshot, &snapshot_row, &vec![], None, None, None)
                 .unwrap();
             last_snapshot = snapshot_row;
             last_snapshot.index_root = index_root;
@@ -812,8 +812,15 @@ fn get_last_snapshot_with_sortition() {
         let chain_tip = SortitionDB::get_canonical_burn_chain_tip(db.conn()).unwrap();
         let mut tx = SortitionHandleTx::begin(&mut db, &chain_tip.sortition_id).unwrap();
 
-        tx.append_chain_tip_snapshot(&chain_tip, &snapshot_without_sortition, &vec![], None, None)
-            .unwrap();
+        tx.append_chain_tip_snapshot(
+            &chain_tip,
+            &snapshot_without_sortition,
+            &vec![],
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         tx.commit().unwrap();
     }
 
@@ -833,8 +840,15 @@ fn get_last_snapshot_with_sortition() {
         let chain_tip = SortitionDB::get_canonical_burn_chain_tip(db.conn()).unwrap();
         let mut tx = SortitionHandleTx::begin(&mut db, &chain_tip.sortition_id).unwrap();
 
-        tx.append_chain_tip_snapshot(&chain_tip, &snapshot_with_sortition, &vec![], None, None)
-            .unwrap();
+        tx.append_chain_tip_snapshot(
+            &chain_tip,
+            &snapshot_with_sortition,
+            &vec![],
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         tx.commit().unwrap();
     }
 
@@ -1021,7 +1035,7 @@ fn test_chain_reorg() {
         ]);
 
         let mut tx = SortitionHandleTx::begin(&mut db, &last_snapshot.sortition_id).unwrap();
-        tx.append_chain_tip_snapshot(&last_snapshot, &next_snapshot, &vec![], None, None)
+        tx.append_chain_tip_snapshot(&last_snapshot, &next_snapshot, &vec![], None, None, None)
             .unwrap();
         tx.commit().unwrap();
 
@@ -1157,7 +1171,14 @@ fn test_chain_reorg() {
 
             let mut tx = SortitionHandleTx::begin(&mut db, &last_snapshot.sortition_id).unwrap();
             let next_index_root = tx
-                .append_chain_tip_snapshot(&last_snapshot, &next_snapshot, &vec![], None, None)
+                .append_chain_tip_snapshot(
+                    &last_snapshot,
+                    &next_snapshot,
+                    &vec![],
+                    None,
+                    None,
+                    None,
+                )
                 .unwrap();
             tx.commit().unwrap();
 
@@ -1236,7 +1257,14 @@ fn test_chain_reorg() {
                 let mut tx =
                     SortitionHandleTx::begin(&mut db, &last_snapshot.sortition_id).unwrap();
                 let next_index_root = tx
-                    .append_chain_tip_snapshot(&last_snapshot, &next_snapshot, &vec![], None, None)
+                    .append_chain_tip_snapshot(
+                        &last_snapshot,
+                        &next_snapshot,
+                        &vec![],
+                        None,
+                        None,
+                        None,
+                    )
                     .unwrap();
                 tx.commit().unwrap();
                 next_index_root
@@ -1267,7 +1295,14 @@ fn test_chain_reorg() {
         let next_index_root = {
             let mut tx = SortitionHandleTx::begin(&mut db, &last_snapshot.sortition_id).unwrap();
             let next_index_root = tx
-                .append_chain_tip_snapshot(&last_snapshot, &next_snapshot, &vec![], None, None)
+                .append_chain_tip_snapshot(
+                    &last_snapshot,
+                    &next_snapshot,
+                    &vec![],
+                    None,
+                    None,
+                    None,
+                )
                 .unwrap();
             tx.commit().unwrap();
             next_index_root
@@ -1459,7 +1494,7 @@ fn test_get_stacks_header_hashes() {
             let mut tx = SortitionHandleTx::begin(&mut db, &last_snapshot.sortition_id).unwrap();
 
             let index_root = tx
-                .append_chain_tip_snapshot(&last_snapshot, &snapshot_row, &vec![], None, None)
+                .append_chain_tip_snapshot(&last_snapshot, &snapshot_row, &vec![], None, None, None)
                 .unwrap();
             last_snapshot = snapshot_row;
             last_snapshot.index_root = index_root;
@@ -1698,7 +1733,7 @@ fn make_fork_run(
         {
             let mut tx = SortitionHandleTx::begin(db, &last_snapshot.sortition_id).unwrap();
             let _index_root = tx
-                .append_chain_tip_snapshot(&last_snapshot, &snapshot, &vec![], None, None)
+                .append_chain_tip_snapshot(&last_snapshot, &snapshot, &vec![], None, None, None)
                 .unwrap();
             tx.commit().unwrap();
         }

--- a/src/chainstate/burn/mod.rs
+++ b/src/chainstate/burn/mod.rs
@@ -481,7 +481,14 @@ mod tests {
                 let mut tx =
                     SortitionHandleTx::begin(&mut db, &prev_snapshot.sortition_id).unwrap();
                 let next_index_root = tx
-                    .append_chain_tip_snapshot(&prev_snapshot, &snapshot_row, &vec![], None, None)
+                    .append_chain_tip_snapshot(
+                        &prev_snapshot,
+                        &snapshot_row,
+                        &vec![],
+                        None,
+                        None,
+                        None,
+                    )
                     .unwrap();
                 burn_block_hashes.push(snapshot_row.sortition_id.clone());
                 tx.commit().unwrap();

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -2568,7 +2568,14 @@ mod test {
             let mut tx = SortitionHandleTx::begin(sortdb, &prev_snapshot.sortition_id).unwrap();
 
             let next_index_root = tx
-                .append_chain_tip_snapshot(&prev_snapshot, &next_snapshot, &vec![], None, None)
+                .append_chain_tip_snapshot(
+                    &prev_snapshot,
+                    &next_snapshot,
+                    &vec![],
+                    None,
+                    None,
+                    None,
+                )
                 .unwrap();
             next_snapshot.index_root = next_index_root;
 


### PR DESCRIPTION
### Description
This change reinstates `PoxId`  as having a constructed values. In `master` currently, the `pox_id` for a branch is always a vector of length 1. In `stacks-blockchain`, this value will be a vector of length `>1` with elements either `true` or `false`.

We make it so that a branch's `pox_id` will be a vector that grows, but all elements are `true`. 

The effect of this change is that we should be able to use the previous inventory sync algorithms mostly unchanged.

### Applicable issues
- addresses #2

### Additional info (benefits, drawbacks, caveats)
The benefit of this is that it should create a working baseline with as little edits as possible.

The caveat is that there is a lot of dead code lurking in the system, but future PR's can trim that.


### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
