### PR TITLE
Test: adapt old faucet integration test to a mock hyperchain test

### DIFF
--- a/testnet/stacks-node/src/burnchains/mock_events.rs
+++ b/testnet/stacks-node/src/burnchains/mock_events.rs
@@ -456,7 +456,7 @@ impl BurnchainController for MockController {
     }
 
     #[cfg(test)]
-    fn bootstrap_chain(&mut self, blocks_count: u64) {
+    fn bootstrap_chain(&mut self, _blocks_count: u64) {
         todo!()
     }
 }

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -5,7 +5,6 @@ use std::time::Instant;
 
 use stacks::burnchains;
 use stacks::burnchains::Burnchain;
-use stacks::burnchains::BurnchainStateTransition;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::operations::BlockstackOperationType;
 use stacks::chainstate::burn::BlockSnapshot;

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -22,18 +22,13 @@ use stacks::chainstate::coordinator::{
     check_chainstate_db_versions, BlockEventDispatcher, ChainsCoordinator, CoordinatorCommunication,
 };
 use stacks::chainstate::stacks::db::{ChainStateBootData, StacksChainState};
-use stacks::net::atlas::{AtlasConfig, Attachment, AttachmentInstance};
-use stx_genesis::GenesisData;
+use stacks::net::atlas::{AtlasConfig, AttachmentInstance};
 
 use crate::burnchains::mock_events::MockController;
 use crate::monitoring::start_serving_monitoring_metrics;
 use crate::neon_node::StacksNode;
-use crate::node::use_test_genesis_chainstate;
 use crate::syncctl::{PoxSyncWatchdog, PoxSyncWatchdogComms};
-use crate::{
-    node::{get_account_balances, get_account_lockups, get_names, get_namespaces},
-    BurnchainController, Config, EventDispatcher,
-};
+use crate::{BurnchainController, Config, EventDispatcher};
 
 use super::RunLoopCallbacks;
 use libc;

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -24,7 +24,6 @@ use stacks::{address::AddressHashMode, util::hash::to_hex};
 
 use super::Config;
 
-// mod integrations;
 // mod mempool;
 #[allow(dead_code)]
 pub mod neon_integrations;
@@ -384,6 +383,7 @@ pub fn make_contract_call_mblock_only(
     )
 }
 
+#[allow(dead_code)]
 fn make_microblock(
     privk: &StacksPrivateKey,
     chainstate: &mut StacksChainState,


### PR DESCRIPTION
This PR tests the RPC interface by repurposing one of the old integration tests (the faucet test) as a mock hyperchain test, exercising the RPC interface (importantly, the chain tip selection).