### PR TITLE
Feat/subnets contract

### DIFF
--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -110,6 +110,20 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: docker build -f ./.github/actions/bitcoin-int-tests/Dockerfile.rustfmt .
 
+  clarinet-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Execute unit tests"
+        uses: docker://hirosystems/clarinet:latest
+        with:
+          args: test --coverage --manifest-path=./core-contracts/Clarinet.toml
+      - name: "Export code coverage"
+        uses: codecov/codecov-action@v1
+        with:
+          files: ./coverage.lcov
+          verbose: true
+
   # # Create distributions
   # dist:
   #   runs-on: ubuntu-latest

--- a/core-contracts/Clarinet.toml
+++ b/core-contracts/Clarinet.toml
@@ -1,0 +1,7 @@
+
+[project]
+name = "core-contracts"
+
+[contracts.subnets]
+path = "../src/chainstate/stacks/boot/subnets.clar"
+depends_on = []

--- a/core-contracts/Clarinet.toml
+++ b/core-contracts/Clarinet.toml
@@ -3,5 +3,5 @@
 name = "core-contracts"
 
 [contracts.subnets]
-path = "../src/chainstate/stacks/boot/subnets.clar"
+path = "contracts/subnets.clar"
 depends_on = []

--- a/core-contracts/contracts/subnets.clar
+++ b/core-contracts/contracts/subnets.clar
@@ -13,30 +13,18 @@
 ;;      secret_key: 7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801
 ;;      btc_address: mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC
 
-
-;; Helper function: maps a principal to an optional principal
-(define-private (map-to-optional (address principal))
-    (some address)
-)
-
 ;; Helper function for fold: if a == b, return none; else return b
-(define-private (is-principal-eq (miner-a (optional principal)) (miner-b (optional principal)))
-    (if (is-eq miner-a miner-b)
+(define-private (is-principal-eq (miner-a principal) (search-for (optional principal)))
+    (if (is-eq (some miner-a) search-for)
         none
-        miner-b
+        search-for
     )
 )
-
 ;; Helper function: returns a boolean indicating whether the given principal is in the list of miners
 (define-private (is-miner (miner principal))
-   (let (
-        (mapped-miners (map map-to-optional miners))
-        (mapped-miner (map-to-optional miner))
-        (fold-result (fold is-principal-eq mapped-miners mapped-miner))
-   )
+   (let ((fold-result (fold is-principal-eq miners (some miner))))
         (is-none fold-result)
-   )
-)
+   ))
 
 ;; Helper function: determines whether the commit-block operation can be carried out
 (define-private (can-commit-block? (commit-block-height uint))

--- a/core-contracts/settings/Devnet.toml
+++ b/core-contracts/settings/Devnet.toml
@@ -1,0 +1,73 @@
+[network]
+name = "devnet"
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+balance = 100_000_000_000_000
+# secret_key: 753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601
+# stx_address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+# btc_address: mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsH
+
+[accounts.wallet_1]
+mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+balance = 100_000_000_000_000
+# secret_key: 7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801
+# stx_address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+# btc_address: mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC
+
+[accounts.wallet_2]
+mnemonic = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital"
+balance = 100_000_000_000_000
+# secret_key: 530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc209101
+# stx_address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+# btc_address: muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG
+
+[accounts.wallet_3]
+mnemonic = "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high"
+balance = 100_000_000_000_000
+# secret_key: d655b2523bcd65e34889725c73064feb17ceb796831c0e111ba1a552b0f31b3901
+# stx_address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+# btc_address: mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7
+
+[accounts.wallet_4]
+mnemonic = "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin"
+balance = 100_000_000_000_000
+# secret_key: f9d7206a47f14d2870c163ebab4bf3e70d18f5d14ce1031f3902fbbc894fe4c701
+# stx_address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+# btc_address: mg1C76bNTutiCDV3t9nWhZs3Dc8LzUufj8
+
+[accounts.wallet_5]
+mnemonic = "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase"
+balance = 100_000_000_000_000
+# secret_key: 3eccc5dac8056590432db6a35d52b9896876a3d5cbdea53b72400bc9c2099fe801
+# stx_address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+# btc_address: mweN5WVqadScHdA81aATSdcVr4B6dNokqx
+
+[accounts.wallet_6]
+mnemonic = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy"
+balance = 100_000_000_000_000
+# secret_key: 7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
+# stx_address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+# btc_address: mzxXgV6e4BZSsz8zVHm3TmqbECt7mbuErt
+
+[accounts.wallet_7]
+mnemonic = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow"
+balance = 100_000_000_000_000
+# secret_key: b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401
+# stx_address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+# btc_address: n37mwmru2oaVosgfuvzBwgV2ysCQRrLko7
+
+[accounts.wallet_8]
+mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
+balance = 100_000_000_000_000
+# secret_key: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01
+# stx_address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+# btc_address: n2v875jbJ4RjBnTjgbfikDfnwsDV5iUByw
+
+[accounts.wallet_9]
+mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+balance = 100_000_000_000_000
+# secret_key: de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b801
+# stx_address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+# btc_address: mjSrB3wS4xab3kYqFktwBzfTdPg367ZJ2d
+

--- a/core-contracts/tests/subnets/subnets_test.ts
+++ b/core-contracts/tests/subnets/subnets_test.ts
@@ -1,0 +1,73 @@
+import { Clarinet, Tx, Chain, Account, Contract, types } from 'https://deno.land/x/clarinet@v0.16.0/index.ts';
+import { assertEquals } from "https://deno.land/std@0.90.0/testing/asserts.ts";
+import { createHash } from "https://deno.land/std@0.107.0/hash/mod.ts";
+
+Clarinet.test({
+    name: "Ensure that block can be committed by subnet miner",
+    async fn(chain: Chain, accounts: Map<string, Account>, contracts: Map<string, Contract>) {
+
+        // valid miner
+        const alice = accounts.get("wallet_1")!;
+        // invalid miner
+        const bob = accounts.get("wallet_2")!;
+        const charlie = accounts.get("wallet_3")!;
+
+        // Successfully commit block at height 0 with alice.
+        let block = chain.mineBlock([
+            Tx.contractCall("subnets", "commit-block",
+                [
+                    types.buff(new Uint8Array([0, 1, 1, 1, 1])),
+                    types.uint(0),
+                ],
+                alice.address),
+        ]);
+        assertEquals(block.height, 2);
+        block.receipts[0].result
+            .expectOk()
+            .expectBuff(new Uint8Array([0, 1, 1, 1, 1]));
+
+
+        // Try and fail to commit a different block, but again at height 0.
+        block = chain.mineBlock([
+            Tx.contractCall("subnets", "commit-block",
+                [
+                    types.buff(new Uint8Array([0, 2, 2, 2, 2])),
+                    types.uint(0),
+                ],
+                alice.address),
+        ]);
+        assertEquals(block.height, 3);
+        block.receipts[0].result
+            .expectErr()
+            .expectInt(3);
+
+
+        // Try and fail to commit a block at height 1 with an invalid miner.
+        block = chain.mineBlock([
+            Tx.contractCall("subnets", "commit-block",
+                [
+                    types.buff(new Uint8Array([0, 2, 2, 2, 2])),
+                    types.uint(1),
+                ],
+                bob.address),
+        ]);
+        assertEquals(block.height, 4);
+        block.receipts[0].result
+            .expectErr()
+            .expectInt(3);
+
+        // Successfully commit block at height 1 with valid miner.
+        block = chain.mineBlock([
+            Tx.contractCall("subnets", "commit-block",
+                [
+                    types.buff(new Uint8Array([0, 2, 2, 2, 2])),
+                    types.uint(1),
+                ],
+                alice.address),
+        ]);
+        assertEquals(block.height, 5);
+        block.receipts[0].result
+            .expectOk()
+            .expectBuff(new Uint8Array([0, 2, 2, 2, 2]));
+    },
+});

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -35,7 +35,7 @@ use vm::eval;
 use vm::representations::SymbolicExpression;
 use vm::test_util::{execute, symbols_from_values, TEST_BURN_STATE_DB, TEST_HEADER_DB};
 use vm::types::Value::Response;
-use vm::types::{OptionalData, PrincipalData, QualifiedContractIdentifier, ResponseData, StandardPrincipalData, TupleData, TupleTypeSignature, TypeSignature, Value, NONE, BuffData};
+use vm::types::{OptionalData, PrincipalData, QualifiedContractIdentifier, ResponseData, StandardPrincipalData, TupleData, TupleTypeSignature, TypeSignature, Value, NONE};
 
 use crate::{
     burnchains::PoxConstants,
@@ -53,11 +53,8 @@ use util_lib::boot::boot_code_id;
 
 use clarity_vm::clarity::Error as ClarityError;
 use core::PEER_VERSION_EPOCH_1_0;
-use clarity::vm::types::{StacksAddressExtensions, SequenceData};
 
 const USTX_PER_HOLDER: u128 = 1_000_000;
-
-const DUMMY_CODE_SUBNETS: &'static str = std::include_str!("subnets.clar");
 
 lazy_static! {
     static ref FIRST_INDEX_BLOCK_HASH: StacksBlockId = StacksBlockHeader::make_index_block_hash(
@@ -67,7 +64,6 @@ lazy_static! {
     static ref POX_CONTRACT_TESTNET: QualifiedContractIdentifier = boot_code_id("pox", false);
     static ref COST_VOTING_CONTRACT_TESTNET: QualifiedContractIdentifier =
         boot_code_id("cost-voting", false);
-    static ref DUMMY_SUBNETS_CONTRACT_ID: QualifiedContractIdentifier = QualifiedContractIdentifier::local("subnets").unwrap();
     static ref USER_KEYS: Vec<StacksPrivateKey> =
         (0..50).map(|_| StacksPrivateKey::new()).collect();
     static ref POX_ADDRS: Vec<Value> = (0..50u64)
@@ -1514,110 +1510,6 @@ fn test_vote_too_many_confirms() {
             .unwrap()
             .0,
             Value::error(Value::Int(17)).unwrap()
-        );
-    });
-}
-
-
-#[test]
-fn test_commit_block() {
-    let mut sim = ClarityTestSim::new();
-
-    let privk = StacksPrivateKey::from_hex(
-        "510f96a8efd0b11e211733c1ac5e3fa6f3d3fcdd62869e376c47decb3e14fea101",
-    )
-        .unwrap();
-    let addr = StacksAddress::from_public_keys(
-        C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
-        &AddressHashMode::SerializeP2PKH,
-        1,
-        &vec![StacksPublicKey::from_private(&privk)],
-    )
-        .unwrap();
-    // Corresponds to 'ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP
-    let miner_principal = addr.to_account_principal();
-
-    // Test committing a block with a valid miner.
-    sim.execute_next_block(|env| {
-        env.initialize_contract(DUMMY_SUBNETS_CONTRACT_ID.clone(), &DUMMY_CODE_SUBNETS)
-            .unwrap();
-
-        let block_hash = vec![1;32];
-        let block_hash_val = Value::buff_from(block_hash.clone()).unwrap();
-        assert_eq!(
-            env.execute_transaction(
-                miner_principal.clone(),
-                DUMMY_SUBNETS_CONTRACT_ID.clone(),
-                "commit-block",
-                &symbols_from_values(vec![block_hash_val.clone(), Value::UInt(0)])
-            )
-                .unwrap()
-                .0,
-            Value::Response(ResponseData {
-                committed: true,
-                data: block_hash_val.into()
-            })
-        );
-    });
-
-    // Test that trying to commit a block with a previously committed block height fails.
-    sim.execute_next_block(|env| {
-        let block_hash = vec![1;32];
-        let block_hash_val = Value::buff_from(block_hash.clone()).unwrap();
-        assert_eq!(
-            env.execute_transaction(
-                miner_principal.clone(),
-                DUMMY_SUBNETS_CONTRACT_ID.clone(),
-                "commit-block",
-                &symbols_from_values(vec![block_hash_val.clone(), Value::UInt(0)])
-            )
-                .unwrap()
-                .0,
-            Value::Response(ResponseData {
-                committed: false,
-                data: Value::Int(3).into()
-            })
-        );
-    });
-
-    // Test committing a block with a valid miner again, this time at a new block height.
-    sim.execute_next_block(|env| {
-        let block_hash = vec![2;32];
-        let block_hash_val = Value::buff_from(block_hash.clone()).unwrap();
-        assert_eq!(
-            env.execute_transaction(
-                miner_principal.clone(),
-                DUMMY_SUBNETS_CONTRACT_ID.clone(),
-                "commit-block",
-                &symbols_from_values(vec![block_hash_val.clone(), Value::UInt(2)])
-            )
-                .unwrap()
-                .0,
-            Value::Response(ResponseData {
-                committed: true,
-                data: block_hash_val.into()
-            })
-        );
-
-    });
-
-    // Trying to commit a block from an invalid miner address should fail.
-    sim.execute_next_block(|env| {
-        let block_hash = vec![3;32];
-        let block_hash_val = Value::buff_from(block_hash.clone()).unwrap();
-        assert_eq!(
-            env.execute_transaction(
-                (&USER_KEYS[0]).into(),
-                DUMMY_SUBNETS_CONTRACT_ID.clone(),
-                "commit-block",
-                &symbols_from_values(vec![block_hash_val.clone(), Value::UInt(3)])
-            )
-                .unwrap()
-                .0,
-            Value::Response(ResponseData {
-                committed: false,
-                data: Value::Int(3).into()
-            })
         );
     });
 }

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -1535,9 +1535,9 @@ fn test_commit_block() {
     )
         .unwrap();
     // Corresponds to 'ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP
-    let principal = addr.to_account_principal();
+    let miner_principal = addr.to_account_principal();
 
-    // Test committing a block with a valid miner
+    // Test committing a block with a valid miner.
     sim.execute_next_block(|env| {
         env.initialize_contract(DUMMY_SUBNETS_CONTRACT_ID.clone(), &DUMMY_CODE_SUBNETS)
             .unwrap();
@@ -1546,7 +1546,7 @@ fn test_commit_block() {
         let block_hash_val = Value::buff_from(block_hash.clone()).unwrap();
         assert_eq!(
             env.execute_transaction(
-                principal.clone(),
+                miner_principal.clone(),
                 DUMMY_SUBNETS_CONTRACT_ID.clone(),
                 "commit-block",
                 &symbols_from_values(vec![block_hash_val.clone(), Value::UInt(0)])
@@ -1560,13 +1560,13 @@ fn test_commit_block() {
         );
     });
 
-    // Test that trying to commit a block with a previously committed block height fails
+    // Test that trying to commit a block with a previously committed block height fails.
     sim.execute_next_block(|env| {
         let block_hash = vec![1;32];
         let block_hash_val = Value::buff_from(block_hash.clone()).unwrap();
         assert_eq!(
             env.execute_transaction(
-                principal.clone(),
+                miner_principal.clone(),
                 DUMMY_SUBNETS_CONTRACT_ID.clone(),
                 "commit-block",
                 &symbols_from_values(vec![block_hash_val.clone(), Value::UInt(0)])
@@ -1580,13 +1580,13 @@ fn test_commit_block() {
         );
     });
 
-    // Test committing a block with a valid miner again
+    // Test committing a block with a valid miner again, this time at a new block height.
     sim.execute_next_block(|env| {
         let block_hash = vec![2;32];
         let block_hash_val = Value::buff_from(block_hash.clone()).unwrap();
         assert_eq!(
             env.execute_transaction(
-                principal.clone(),
+                miner_principal.clone(),
                 DUMMY_SUBNETS_CONTRACT_ID.clone(),
                 "commit-block",
                 &symbols_from_values(vec![block_hash_val.clone(), Value::UInt(2)])

--- a/src/chainstate/stacks/boot/subnets.clar
+++ b/src/chainstate/stacks/boot/subnets.clar
@@ -9,6 +9,11 @@
 (define-constant miners (list 'SPAXYA5XS51713FDTQ8H94EJ4V579CXMTRNBZKSF 'SP3X6QWWETNBZWGBK6DRGTR1KX50S74D3433WDGJY
     'ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5))
 
+;; Testing info for 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5:
+;;      secret_key: 7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801
+;;      btc_address: mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC
+
+
 ;; Helper function: maps a principal to an optional principal
 (define-private (map-to-optional (address principal))
     (some address)
@@ -34,7 +39,7 @@
 )
 
 ;; Helper function: determines whether the commit-block operation can be carried out
-(define-private (can-commit-block? (block (buff 32)) (commit-block-height uint))
+(define-private (can-commit-block? (commit-block-height uint))
     (begin
         ;; check no block has been committed at this height
         (asserts! (is-none (map-get? block-commits commit-block-height)) (err ERR_BLOCK_ALREADY_COMMITTED))
@@ -58,7 +63,7 @@
 ;; Subnets miners call this to commit a block at a particular height
 (define-public (commit-block (block (buff 32)) (commit-block-height uint))
     (begin
-        (unwrap! (can-commit-block? block commit-block-height) (err ERR_VALIDATION_FAILED))
+        (unwrap! (can-commit-block? commit-block-height) (err ERR_VALIDATION_FAILED))
         (inner-commit-block block commit-block-height)
     )
 )

--- a/src/chainstate/stacks/boot/subnets.clar
+++ b/src/chainstate/stacks/boot/subnets.clar
@@ -6,7 +6,8 @@
 
 ;; Map from Stacks block height to block commit
 (define-map block-commits uint (buff 32))
-(define-constant miners (list 'SPAXYA5XS51713FDTQ8H94EJ4V579CXMTRNBZKSF 'SP3X6QWWETNBZWGBK6DRGTR1KX50S74D3433WDGJY 'ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP))
+(define-constant miners (list 'SPAXYA5XS51713FDTQ8H94EJ4V579CXMTRNBZKSF 'SP3X6QWWETNBZWGBK6DRGTR1KX50S74D3433WDGJY
+    'ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5))
 
 ;; Helper function: maps a principal to an optional principal
 (define-private (map-to-optional (address principal))

--- a/src/chainstate/stacks/boot/subnets.clar
+++ b/src/chainstate/stacks/boot/subnets.clar
@@ -8,12 +8,12 @@
 (define-map block-commits uint (buff 32))
 (define-constant miners (list 'SPAXYA5XS51713FDTQ8H94EJ4V579CXMTRNBZKSF 'SP3X6QWWETNBZWGBK6DRGTR1KX50S74D3433WDGJY 'ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP))
 
-;; maps a principal to an optional principal
+;; Helper function: maps a principal to an optional principal
 (define-private (map-to-optional (address principal))
     (some address)
 )
 
-;; if a == b, return none; else return a
+;; Helper function for fold: if a == b, return none; else return b
 (define-private (is-principal-eq (miner-a (optional principal)) (miner-b (optional principal)))
     (if (is-eq miner-a miner-b)
         none
@@ -21,18 +21,18 @@
     )
 )
 
-;; Returns a boolean indicating whether the given principal is in the list of miners
+;; Helper function: returns a boolean indicating whether the given principal is in the list of miners
 (define-private (is-miner (miner principal))
    (let (
         (mapped-miners (map map-to-optional miners))
         (mapped-miner (map-to-optional miner))
-        (is-in-list (fold is-principal-eq mapped-miners mapped-miner))
+        (fold-result (fold is-principal-eq mapped-miners mapped-miner))
    )
-        (is-none is-in-list)
+        (is-none fold-result)
    )
 )
 
-;; Determines whether the commit-block operated can be carried out
+;; Helper function: determines whether the commit-block operation can be carried out
 (define-private (can-commit-block? (block (buff 32)) (commit-block-height uint))
     (begin
         ;; check no block has been committed at this height
@@ -45,7 +45,7 @@
     )
 )
 
-;; Modifies the block-commits map with a new commit and has a print
+;; Helper function: modifies the block-commits map with a new commit and prints related info
 (define-private (inner-commit-block (block (buff 32)) (commit-block-height uint))
     (begin
         (map-set block-commits commit-block-height block)

--- a/src/chainstate/stacks/boot/subnets.clar
+++ b/src/chainstate/stacks/boot/subnets.clar
@@ -1,0 +1,73 @@
+;; The .subnets contract
+;; Error codes
+(define-constant ERR_BLOCK_ALREADY_COMMITTED 1)
+(define-constant ERR_INVALID_MINER 2)
+(define-constant ERR_VALIDATION_FAILED 3)
+
+;; Map from Stacks block height to block commit
+(define-map block-commits uint (buff 32))
+(define-constant miners (list 'SPAXYA5XS51713FDTQ8H94EJ4V579CXMTRNBZKSF 'SP3X6QWWETNBZWGBK6DRGTR1KX50S74D3433WDGJY 'ST1AW6EKPGT61SQ9FNVDS17RKNWT8ZP582VF9HSCP))
+
+;; maps a principal to an optional principal
+(define-private (map-to-optional (address principal))
+    (some address)
+)
+
+;; if a == b, return none; else return a
+(define-private (is-principal-eq (miner-a (optional principal)) (miner-b (optional principal)))
+    (if (is-eq miner-a miner-b)
+        none
+        miner-b
+    )
+)
+
+;; Returns a boolean indicating whether the given principal is in the list of miners
+(define-private (is-miner (miner principal))
+   (let (
+        (mapped-miners (map map-to-optional miners))
+        (mapped-miner (map-to-optional miner))
+        (is-in-list (fold is-principal-eq mapped-miners mapped-miner))
+   )
+        (is-none is-in-list)
+   )
+)
+
+;; Determines whether the commit-block operated can be carried out
+(define-private (can-commit-block? (block (buff 32)) (commit-block-height uint))
+    (begin
+        ;; check no block has been committed at this height
+        (asserts! (is-none (map-get? block-commits commit-block-height)) (err ERR_BLOCK_ALREADY_COMMITTED))
+
+        ;; check that the tx sender is one of the miners
+        (asserts! (is-miner tx-sender) (err ERR_INVALID_MINER))
+
+        (ok true)
+    )
+)
+
+;; Modifies the block-commits map with a new commit and has a print
+(define-private (inner-commit-block (block (buff 32)) (commit-block-height uint))
+    (begin
+        (map-set block-commits commit-block-height block)
+        (print { event: "block-commit", block-commit: block})
+        (ok block)
+    )
+)
+
+;; Subnets miners call this to commit a block at a particular height
+(define-public (commit-block (block (buff 32)) (commit-block-height uint))
+    (begin
+        (unwrap! (can-commit-block? block commit-block-height) (err ERR_VALIDATION_FAILED))
+        (inner-commit-block block commit-block-height)
+    )
+)
+
+
+;; Implement functions below in M2
+;; user: deposit asset
+
+;; miner: acknowledge deposit
+
+;; user: issue withdraw request
+
+;; miner: approve withdraw


### PR DESCRIPTION
### Description
Added a draft of the subnets clarity contract, and added some tests. The contract implements the function `commit-block`. 
Put contract in core-contracts/..
Also sets up clarinet testing. 

### Applicable issues
- implements #10

### Additional info (benefits, drawbacks, caveats)
- I put the contract into the boot directory. I did this because I wasn't sure where else to leave a "dangling" contract. Also, this makes it easier to used the existing contract_tests.rs. If this choice doesn't make sense, happy to move the file. 

### Checklist
- [x] Test coverage for new or modified code paths
