### PR TITLE
HTTP Listener test fixes

### DIFF
--- a/.github/actions/bitcoin-int-tests/Dockerfile.stacks-node
+++ b/.github/actions/bitcoin-int-tests/Dockerfile.stacks-node
@@ -1,4 +1,6 @@
-FROM rust:bullseye AS test
+FROM blockstack/stacks-blockchain:2.05.0.1.0-stretch as stacks-node
+
+FROM rust:stretch AS test
 
 WORKDIR /build
 
@@ -7,12 +9,15 @@ RUN rustup override set nightly-2022-01-14 && \
     cargo install grcov
 
 ENV RUSTFLAGS="-Zinstrument-coverage" \
-    LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw"
-    
+    LLVM_PROFILE_FILE="stacks-blockchain-%p-%m.profraw" \
+    STACKS_NODE_TEST="1"
+
+COPY --from=stacks-node /bin/stacks-node /bin/
+
 COPY . .
 
 RUN cargo build --workspace && \
-    cargo test --workspace --bin=hyperchain-node -- --ignored --test-threads 1
+    cargo test --workspace --bin=hyperchain-node -- l1_observer_test --test-threads 1
 
 # Generate coverage report and upload it to codecov
 RUN grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info

--- a/.github/workflows/stacks-blockchain.yml
+++ b/.github/workflows/stacks-blockchain.yml
@@ -53,7 +53,23 @@ jobs:
           files: ./coverage-output/lcov.info
           name: unit_tests
           fail_ci_if_error: true
-
+  # Run tests that require stacks-node
+  layer-1-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run units tests (with coverage)
+        env:
+          DOCKER_BUILDKIT: 1
+        # Remove .dockerignore file so codecov has access to git info
+        run: |
+          rm .dockerignore
+          docker build -o coverage-output -f ./.github/actions/bitcoin-int-tests/Dockerfile.stacks-node .
+      - uses: codecov/codecov-action@v2
+        with:
+          files: ./coverage-output/lcov.info
+          name: integration_tests
+          fail_ci_if_error: true
   # Run integration tests
   integration-tests:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,6 +1257,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperchain-node"
+version = "0.1.0"
+dependencies = [
+ "async-h1",
+ "async-std",
+ "backtrace",
+ "base64 0.12.3",
+ "blockstack-core",
+ "clarity",
+ "http-types",
+ "lazy_static",
+ "libc",
+ "pico-args",
+ "rand 0.7.3",
+ "reqwest",
+ "ring",
+ "rusqlite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slog",
+ "stacks-common",
+ "stx-genesis",
+ "tokio",
+ "toml",
+ "warp",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2668,35 +2697,6 @@ dependencies = [
  "slog-json",
  "slog-term",
  "time 0.2.27",
-]
-
-[[package]]
-name = "stacks-node"
-version = "0.1.0"
-dependencies = [
- "async-h1",
- "async-std",
- "backtrace",
- "base64 0.12.3",
- "blockstack-core",
- "clarity",
- "http-types",
- "lazy_static",
- "libc",
- "pico-args",
- "rand 0.7.3",
- "reqwest",
- "ring",
- "rusqlite",
- "serde",
- "serde_derive",
- "serde_json",
- "slog",
- "stacks-common",
- "stx-genesis",
- "tokio",
- "toml",
- "warp",
 ]
 
 [[package]]

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -101,6 +101,7 @@ pub struct BurnchainParameters {
 impl BurnchainParameters {
     pub fn from_params(chain: &str, network: &str) -> Option<BurnchainParameters> {
         match (chain, network) {
+            ("mockstack", "mainnet") => Some(BurnchainParameters::hyperchain_mocknet()),
             ("bitcoin", "mainnet") => Some(BurnchainParameters::bitcoin_mainnet()),
             ("bitcoin", "testnet") => Some(BurnchainParameters::bitcoin_testnet()),
             ("bitcoin", "regtest") => Some(BurnchainParameters::bitcoin_regtest()),
@@ -110,7 +111,7 @@ impl BurnchainParameters {
 
     pub fn hyperchain_mocknet() -> BurnchainParameters {
         BurnchainParameters {
-            chain_name: "bitcoin".to_string(),
+            chain_name: "mockstack".to_string(),
             network_name: "mainnet".into(),
             network_id: 0,
             stable_confirmations: 0,

--- a/src/chainstate/stacks/boot/contract_tests.rs
+++ b/src/chainstate/stacks/boot/contract_tests.rs
@@ -35,7 +35,10 @@ use vm::eval;
 use vm::representations::SymbolicExpression;
 use vm::test_util::{execute, symbols_from_values, TEST_BURN_STATE_DB, TEST_HEADER_DB};
 use vm::types::Value::Response;
-use vm::types::{OptionalData, PrincipalData, QualifiedContractIdentifier, ResponseData, StandardPrincipalData, TupleData, TupleTypeSignature, TypeSignature, Value, NONE};
+use vm::types::{
+    OptionalData, PrincipalData, QualifiedContractIdentifier, ResponseData, StandardPrincipalData,
+    TupleData, TupleTypeSignature, TypeSignature, Value, NONE,
+};
 
 use crate::{
     burnchains::PoxConstants,

--- a/testnet/stacks-node/Cargo.toml
+++ b/testnet/stacks-node/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stacks-node"
+name = "hyperchain-node"
 version = "0.1.0"
 authors = ["Ludo Galabru <ludovic@blockstack.com>"]
 edition = "2018"
@@ -35,7 +35,7 @@ version = "=0.24.2"
 features = ["blob", "serde_json", "i128_blob", "bundled", "trace"]
 
 [[bin]]
-name = "stacks-node"
+name = "hyperchain-node"
 path = "src/main.rs"
 
 [features]

--- a/testnet/stacks-node/src/burnchains/mock_events.rs
+++ b/testnet/stacks-node/src/burnchains/mock_events.rs
@@ -468,12 +468,12 @@ pub struct MockParser {
     watch_contract: QualifiedContractIdentifier,
 }
 
-    #[derive(Clone)]
-    pub struct MockHeader {
-        pub height: u64,
-        pub index_hash: StacksBlockId,
-        pub parent_index_hash: StacksBlockId,
-    }
+#[derive(Clone)]
+pub struct MockHeader {
+    pub height: u64,
+    pub index_hash: StacksBlockId,
+    pub parent_index_hash: StacksBlockId,
+}
 #[derive(Clone)]
 pub struct BlockIPC(pub NewBlock);
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -41,6 +41,9 @@ const LEADER_KEY_TX_ESTIM_SIZE: u64 = 290;
 const BLOCK_COMMIT_TX_ESTIM_SIZE: u64 = 350;
 const INV_REWARD_CYCLES_TESTNET: u64 = 6;
 
+pub const BURNCHAIN_NAME_STACKS_L1: &str = "stacks_layer_1";
+pub const BURNCHAIN_NAME_MOCKSTACK: &str = "mockstack";
+
 #[derive(Clone, Deserialize, Default)]
 pub struct ConfigFile {
     pub burnchain: Option<BurnchainConfigFile>,
@@ -987,6 +990,11 @@ impl Default for BurnchainConfig {
 }
 
 impl BurnchainConfig {
+    /// Does this configuration need a L1 observer to be spawned?
+    pub fn spawn_l1_observer(&self) -> bool {
+        self.chain == BURNCHAIN_NAME_STACKS_L1
+    }
+
     pub fn get_rpc_url(&self) -> String {
         let scheme = match self.rpc_ssl {
             true => "https://",
@@ -1194,8 +1202,12 @@ impl Config {
         coordinator: CoordinatorChannels,
     ) -> Option<Box<dyn BurnchainController + Send>> {
         match self.burnchain.chain.as_str() {
-            "mockstack" => Some(Box::new(MockController::new(self.clone(), coordinator))),
-            "stacks_layer_1" => Some(Box::new(L1Controller::new(self.clone(), coordinator))),
+            BURNCHAIN_NAME_MOCKSTACK => {
+                Some(Box::new(MockController::new(self.clone(), coordinator)))
+            }
+            BURNCHAIN_NAME_STACKS_L1 => {
+                Some(Box::new(L1Controller::new(self.clone(), coordinator)))
+            }
             _ => {
                 warn!(
                     "No matching controller for `chain`: {}",

--- a/testnet/stacks-node/src/run_loop/l1_observer.rs
+++ b/testnet/stacks-node/src/run_loop/l1_observer.rs
@@ -15,10 +15,7 @@ pub const EVENT_OBSERVER_PORT: u16 = 50303;
 /// Adds in `channel` to downstream functions.
 fn with_db(
     channel: Arc<dyn BurnchainChannel>,
-) -> impl Filter<
-    Extract = (Arc<dyn BurnchainChannel>,),
-    Error = std::convert::Infallible,
-> + Clone {
+) -> impl Filter<Extract = (Arc<dyn BurnchainChannel>,), Error = std::convert::Infallible> + Clone {
     warp::any().map(move || channel.clone())
 }
 
@@ -46,7 +43,7 @@ async fn serve(
     let new_blocks = first_part.and_then(handle_new_block);
 
     info!("Binding warp server.");
-    let (addr, server) = warp::serve(new_blocks).bind_with_graceful_shutdown(
+    let (_addr, server) = warp::serve(new_blocks).bind_with_graceful_shutdown(
         ([127, 0, 0, 1], EVENT_OBSERVER_PORT),
         async {
             signal_receiver.await.ok();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -24,7 +24,7 @@ use crate::tests::{
 };
 use crate::{Config, ConfigFile, Keychain};
 
-pub fn neon_integration_test_conf() -> (Config, StacksAddress) {
+pub fn mockstack_test_conf() -> (Config, StacksAddress) {
     let mut conf = super::new_test_conf();
 
     let keychain = Keychain::default(conf.node.seed.clone());
@@ -32,8 +32,8 @@ pub fn neon_integration_test_conf() -> (Config, StacksAddress) {
     conf.node.miner = true;
     conf.node.wait_time_for_microblocks = 500;
     conf.burnchain.burn_fee_cap = 20000;
-
-    conf.burnchain.mode = "neon".into();
+    conf.burnchain.chain = "mockstack".into();
+    conf.burnchain.mode = "hyperchain".into();
     conf.burnchain.username = Some("neon-tester".into());
     conf.burnchain.password = Some("neon-tester-pass".into());
     conf.burnchain.peer_host = "127.0.0.1".into();
@@ -456,8 +456,10 @@ fn is_close_f64(a: f64, b: f64) -> bool {
 
 #[test]
 #[ignore]
-fn bitcoind_integration_test() {
-    let (mut conf, miner_account) = neon_integration_test_conf();
+/// Simple test for the mock backend: test that the hyperchain miner
+/// is capable of producing blocks
+fn mockstack_integration_test() {
+    let (mut conf, miner_account) = mockstack_test_conf();
     let prom_bind = format!("{}:{}", "127.0.0.1", 6000);
     conf.node.prometheus_bind = Some(prom_bind.clone());
 
@@ -625,7 +627,7 @@ const FAUCET_CONTRACT: &'static str = "
 /// processes the blocks
 #[test]
 fn faucet_test() {
-    let (mut conf, miner_account) = neon_integration_test_conf();
+    let (mut conf, miner_account) = mockstack_test_conf();
 
     let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
     let sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();


### PR DESCRIPTION
This contains a handful of changes:

1. Renames the binary output to `hyperchain-node` from `stacks-node`
2. Changes the way the path settings work for the l1_observer_test so that it defaults to running `stacks-node` out of the OS `PATH`.
3. Some fixes to the configurations so that the mockstack tests work again.
4. Changes to the github actions to _hopefully_ execute all of these tests correctly.