### PR TITLE
feat: L1Controller uses DBBurnchainIndexer

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -194,6 +194,7 @@ impl Burnchain {
             }
         };
 
+        // Note: This is where Burnchain gets created.
         Ok(Burnchain {
             peer_version,
             network_id: params.network_id,
@@ -301,6 +302,7 @@ impl Burnchain {
             0
         };
 
+        info!("this burnchain {:?}", &self);
         if headers_height == 0 || headers_height < self.first_block_height {
             debug!("Fetch initial headers");
             indexer.sync_headers(headers_height, None).map_err(|e| {

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -194,7 +194,6 @@ impl Burnchain {
             }
         };
 
-        // Note: This is where Burnchain gets created.
         Ok(Burnchain {
             peer_version,
             network_id: params.network_id,
@@ -302,7 +301,6 @@ impl Burnchain {
             0
         };
 
-        info!("this burnchain {:?}", &self);
         if headers_height == 0 || headers_height < self.first_block_height {
             debug!("Fetch initial headers");
             indexer.sync_headers(headers_height, None).map_err(|e| {

--- a/src/burnchains/events.rs
+++ b/src/burnchains/events.rs
@@ -20,7 +20,7 @@ use super::StacksHyperOpType;
 
 /// Parsing struct for the transaction event types of the
 /// `stacks-node` events API
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Serialize)]
 pub enum TxEventType {
     ContractEvent,
     Other,
@@ -28,7 +28,7 @@ pub enum TxEventType {
 
 /// Parsing struct for the contract_event field in transaction events
 /// of the `stacks-node` events API
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ContractEvent {
     #[serde(deserialize_with = "deser_contract_identifier")]
     pub contract_identifier: QualifiedContractIdentifier,
@@ -39,7 +39,7 @@ pub struct ContractEvent {
 
 /// Parsing struct for the transaction events of the `stacks-node`
 /// events API
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct NewBlockTxEvent {
     #[serde(deserialize_with = "deser_txid")]
     pub txid: Txid,
@@ -53,7 +53,7 @@ pub struct NewBlockTxEvent {
 
 /// Parsing struct for the new block events of the `stacks-node`
 /// events API
-#[derive(Deserialize, Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct NewBlock {
     pub block_height: u64,
     pub burn_block_time: u64,

--- a/src/burnchains/indexer.rs
+++ b/src/burnchains/indexer.rs
@@ -106,7 +106,8 @@ pub trait BurnchainIndexer {
     fn drop_headers(&mut self, new_height: u64) -> Result<(), burnchain_error>;
 
     /// Reads in the headers from `start_block` to `end_block`.
-    /// Returns an error if the headers in this range are not available.
+    /// If the headers in this range do not exist, it is not an error, and a truncated vector
+    /// is returned.
     fn read_headers(
         &self,
         start_block: u64,

--- a/src/burnchains/indexer.rs
+++ b/src/burnchains/indexer.rs
@@ -68,9 +68,7 @@ pub trait BurnchainIndexer {
     type P: BurnchainBlockParser<B = Self::B> + Send + Sync;
     type D: BurnchainBlockDownloader<B = Self::B> + Send + Sync;
 
-    /// Instructs the sub-class to connect to databases.
-    /// This call should also check if any databases need to be initialized. If so, and `readwrite` is true,
-    /// then initialize them. If initialization is needed and `readwrite` is false, panic.
+    /// This call should be a no-op. TODO: Remove this.
     fn connect(&mut self, readwrite: bool) -> Result<(), burnchain_error>;
 
     /// Gets a channel to input blocks to this indexer.
@@ -83,17 +81,32 @@ pub trait BurnchainIndexer {
 
     fn get_stacks_epochs(&self) -> Vec<StacksEpoch>;
 
+    /// Returns the path for the database underlying this.
     fn get_headers_path(&self) -> String;
-    fn get_headers_height(&self) -> Result<u64, burnchain_error>;
+
+    /// Returns the relative height (relative to the first block) of the highest header.
     fn get_highest_header_height(&self) -> Result<u64, burnchain_error>;
+
+    /// Returns `get_highest_header_height() + 1.
+    fn get_headers_height(&self) -> Result<u64, burnchain_error>;
+
+    /// Returns true if there has been a reorg since the last time this function was called.
     fn find_chain_reorg(&mut self) -> Result<u64, burnchain_error>;
+
+    /// This method will block until at least one header (the "first" tracked header) has been read.
+    /// 
+    /// It will return the highest height known about.
     fn sync_headers(
         &mut self,
         start_height: u64,
         end_height: Option<u64>,
     ) -> Result<u64, burnchain_error>;
+
+    /// This is a no-op for hyper-chains. TODO: Remove this.
     fn drop_headers(&mut self, new_height: u64) -> Result<(), burnchain_error>;
 
+    /// Reads in the headers from `start_block` to `end_block`.
+    /// Returns an error if the headers in this range are not available.
     fn read_headers(
         &self,
         start_block: u64,

--- a/src/burnchains/indexer.rs
+++ b/src/burnchains/indexer.rs
@@ -94,7 +94,7 @@ pub trait BurnchainIndexer {
     fn find_chain_reorg(&mut self) -> Result<u64, burnchain_error>;
 
     /// This method will block until at least one header (the "first" tracked header) has been read.
-    /// 
+    ///
     /// It will return the highest height known about.
     fn sync_headers(
         &mut self,

--- a/src/util_lib/db.rs
+++ b/src/util_lib/db.rs
@@ -173,7 +173,10 @@ pub trait FromColumn<T> {
 
 impl FromRow<u64> for u64 {
     fn from_row<'a>(row: &'a Row) -> Result<u64, Error> {
-        let x: i64 = row.get_unwrap(0);
+        let x: i64 = match row.get(0) {
+            Ok(val) => val,
+            Err(e) => {return Err(Error::NotFoundError);},
+        };
         if x < 0 {
             return Err(Error::ParseError);
         }

--- a/src/util_lib/db.rs
+++ b/src/util_lib/db.rs
@@ -549,6 +549,20 @@ pub fn db_mkdirs(path_str: &str) -> Result<String, Error> {
     Ok(marf_path)
 }
 
+/// Ensures that the base path of `full_path_str` exists.
+/// E.g. `ensure_directory_exists("/a/b/c.txt")` will make sure the directory `/a/b` will exist.
+/// Panics if the user passes "/".
+pub fn ensure_base_directory_exists(full_path_str: &str) -> Result<(), Error> {
+    let mut path = PathBuf::from(full_path_str);
+    let could_pop = path.pop();
+    // let error = format!("Invalid path passed to `ensure_directory_exists`: {}", &full_path_str);
+    assert!(could_pop, "Invalid path passed to `ensure_directory_exists`: {}", &full_path_str);
+
+    // This will not failif `path` already exists.
+    fs::create_dir_all(path).map_err(Error::IOError)?;
+    Ok(())
+}
+
 /// Read-only connection to a MARF-indexed DB
 pub struct IndexDBConn<'a, C, T: MarfTrieId> {
     pub index: &'a MARF<T>,

--- a/src/util_lib/db.rs
+++ b/src/util_lib/db.rs
@@ -551,7 +551,11 @@ pub fn ensure_base_directory_exists(full_path_str: &str) -> Result<(), Error> {
     let mut path = PathBuf::from(full_path_str);
     let could_pop = path.pop();
     // let error = format!("Invalid path passed to `ensure_directory_exists`: {}", &full_path_str);
-    assert!(could_pop, "Invalid path passed to `ensure_directory_exists`: {}", &full_path_str);
+    assert!(
+        could_pop,
+        "Invalid path passed to `ensure_directory_exists`: {}",
+        &full_path_str
+    );
 
     // This will not failif `path` already exists.
     fs::create_dir_all(path).map_err(Error::IOError)?;

--- a/src/util_lib/db.rs
+++ b/src/util_lib/db.rs
@@ -173,12 +173,7 @@ pub trait FromColumn<T> {
 
 impl FromRow<u64> for u64 {
     fn from_row<'a>(row: &'a Row) -> Result<u64, Error> {
-        let x: i64 = match row.get(0) {
-            Ok(val) => val,
-            Err(e) => {
-                return Err(Error::NotFoundError);
-            }
-        };
+        let x: i64 = row.get_unwrap(0);
         if x < 0 {
             return Err(Error::ParseError);
         }

--- a/src/util_lib/db.rs
+++ b/src/util_lib/db.rs
@@ -175,7 +175,9 @@ impl FromRow<u64> for u64 {
     fn from_row<'a>(row: &'a Row) -> Result<u64, Error> {
         let x: i64 = match row.get(0) {
             Ok(val) => val,
-            Err(e) => {return Err(Error::NotFoundError);},
+            Err(e) => {
+                return Err(Error::NotFoundError);
+            }
         };
         if x < 0 {
             return Err(Error::ParseError);

--- a/testnet/stacks-node/src/burnchains/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/db_indexer.rs
@@ -398,11 +398,13 @@ impl DBBurnchainIndexer {
     /// Create a new indexer and connect to the database. If the database schema doesn't exist,
     /// if `readwrite` is true, instantiate it, otherwise error.
     pub fn new(config: BurnchainConfig, readwrite: bool) -> Result<DBBurnchainIndexer, Error> {
+        info!("Creating DBBurnchainIndexer with config: {:?}", &config);
         let first_burn_header_hash = BurnchainHeaderHash(
-            Sha256dHash::from_hex(&config.first_burn_header_hash)
+            StacksBlockId::from_hex(&config.first_burn_header_hash)
                 .expect("Could not parse `first_burn_header_hash`.")
                 .0,
         );
+        info!("first_burn_header_hash {:?}", first_burn_header_hash);
 
         let connection = create_db_and_maybe_instantiate(&config.indexer_base_db_path, readwrite)?;
         let last_canonical_tip = get_canonical_chain_tip(&connection);
@@ -635,7 +637,7 @@ impl DBBurnchainIndexer {
     pub fn get_header_for_hash(&self, hash: &BurnchainHeaderHash) -> BurnHeaderDBRow {
         let row = query_row::<BurnHeaderDBRow, _>(
             &self.connection,
-            "SELECT * FROM headers WHERE burn_header_hash = ?1",
+            "SELECT * FROM headers WHERE header_hash = ?1",
             &[&hash],
         )
         .expect(&format!(

--- a/testnet/stacks-node/src/burnchains/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/db_indexer.rs
@@ -612,9 +612,6 @@ impl BurnchainIndexer for DBBurnchainIndexer {
         _end_height: Option<u64>,
     ) -> Result<u64, BurnchainError> {
         wait_for_first_block(&self.connection)
-        // // We are not going to download blocks or wait here.
-        // // The returned result is always just the highest block known about.
-        // self.get_highest_header_height()
     }
 
     fn drop_headers(&mut self, _new_height: u64) -> Result<(), BurnchainError> {
@@ -660,7 +657,9 @@ impl BurnchainIndexer for DBBurnchainIndexer {
     }
 
     fn parser(&self) -> Self::P {
-        todo!()
+        DBBurnchainParser {
+            watch_contract: self.config.contract_identifier.clone(),
+        }
     }
     fn downloader(&self) -> Self::D {
         DBBlockDownloader {

--- a/testnet/stacks-node/src/burnchains/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/db_indexer.rs
@@ -19,7 +19,7 @@ use stacks::burnchains::{self, BurnchainBlock, Error as BurnchainError, StacksHy
 use stacks::chainstate::burn::db::DBConn;
 use stacks::core::StacksEpoch;
 use stacks::types::chainstate::{BurnchainHeaderHash, StacksBlockId};
-use stacks::util_lib::db::Error as DBError;
+use stacks::util_lib::db::{Error as DBError, ensure_base_directory_exists};
 use stacks::util_lib::db::{query_row, u64_to_sql, FromRow};
 use stacks::util_lib::db::{sqlite_open, Error as db_error};
 use stacks_common::deps_common::bitcoin::util::hash::Sha256dHash;
@@ -358,6 +358,8 @@ fn create_db_and_maybe_instantiate(
     db_path: &String,
     readwrite: bool,
 ) -> Result<DBConn, BurnchainError> {
+    ensure_base_directory_exists(db_path)?;
+    
     let mut create_flag = false;
     let open_flags = match fs::metadata(db_path) {
         Err(e) => {

--- a/testnet/stacks-node/src/burnchains/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/db_indexer.rs
@@ -228,6 +228,8 @@ struct DBBurnBlockInputChannel {
 
 impl BurnchainChannel for DBBurnBlockInputChannel {
     /// TODO: add comment.
+    /// TODO: Make this method sensitive to `first_burn_header_hash`, and don't push
+    /// anything until we have seen that block.
     fn push_block(&self, new_block: NewBlock) -> Result<(), BurnchainError> {
         info!("BurnchainChannel::push_block pushing: {:?}", &new_block);
         // Re-open the connection.
@@ -294,11 +296,6 @@ impl BurnchainChannel for DBBurnBlockInputChannel {
         }
 
         transaction.commit()?;
-
-        info!(
-            "BurnchainChannel::push_block succeeds for: {:?}",
-            &new_block
-        );
 
         Ok(())
     }

--- a/testnet/stacks-node/src/burnchains/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/db_indexer.rs
@@ -227,6 +227,7 @@ struct DBBurnBlockInputChannel {
 
 impl BurnchainChannel for DBBurnBlockInputChannel {
     fn push_block(&self, new_block: NewBlock) -> Result<(), BurnchainError> {
+        info!("BurnchainChannel::push_block pushing: {:?}", &new_block);
         // Re-open the connection.
         let open_flags = OpenFlags::SQLITE_OPEN_READ_WRITE;
         let mut connection = sqlite_open(&self.output_db_path, open_flags, true)?;
@@ -288,6 +289,8 @@ impl BurnchainChannel for DBBurnBlockInputChannel {
         }
 
         transaction.commit()?;
+
+        info!("BurnchainChannel::push_block succeeds for: {:?}", &new_block);
 
         Ok(())
     }

--- a/testnet/stacks-node/src/burnchains/l1_events.rs
+++ b/testnet/stacks-node/src/burnchains/l1_events.rs
@@ -275,7 +275,7 @@ impl BurnchainController for L1Controller {
         )
     }
     fn get_channel(&self) -> Arc<dyn BurnchainChannel> {
-        STATIC_EVENTS_STREAM.clone()
+        self.indexer.get_channel()
     }
     fn submit_operation(
         &mut self,

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -29,6 +29,7 @@ mod tests;
 
 #[derive(Debug)]
 pub enum Error {
+    UnsupportedBurnchain(String),
     CoordinatorClosed,
     IndexerError(burnchains::Error),
 }
@@ -36,6 +37,9 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Error::UnsupportedBurnchain(ref chain_name) => {
+                write!(f, "Burnchain is not supported: {:?}", chain_name)
+            }
             Error::CoordinatorClosed => write!(f, "ChainsCoordinator closed"),
             Error::IndexerError(ref e) => write!(f, "Indexer error: {:?}", e),
         }

--- a/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
@@ -19,7 +19,7 @@ fn make_test_config() -> BurnchainConfig {
 
 /// Make indexer with test settings.
 fn make_test_indexer() -> DBBurnchainIndexer {
-    DBBurnchainIndexer::new(make_test_config()).expect("Couldn't create indexer.")
+    DBBurnchainIndexer::new(make_test_config(), true).expect("Couldn't create indexer.")
 }
 
 /// Tests that we can make a DBBurnchainIndexer and connect.

--- a/testnet/stacks-node/src/burnchains/tests/mod.rs
+++ b/testnet/stacks-node/src/burnchains/tests/mod.rs
@@ -15,7 +15,7 @@ use super::mock_events::BlockIPC;
 
 pub mod db_indexer;
 
-fn random_sortdb_test_dir() -> String {
+pub fn random_sortdb_test_dir() -> String {
     let mut rng = rand::thread_rng();
     let mut buf = [0u8; 32];
     rng.fill_bytes(&mut buf);

--- a/testnet/stacks-node/src/run_loop/l1_observer.rs
+++ b/testnet/stacks-node/src/run_loop/l1_observer.rs
@@ -27,7 +27,10 @@ async fn handle_new_block(
     let parsed_block: NewBlock =
         serde_json::from_str(&block.to_string()).expect("Failed to parse events JSON");
     info!("handle_new_block receives new block {:?}", &parsed_block);
-    channel.push_block(parsed_block);
+    match channel.push_block(parsed_block) {
+        Ok(_) => {}
+        Err(e) => panic!("error {:?}", &e),
+    };
     Ok(warp::http::StatusCode::OK)
 }
 

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -23,6 +23,7 @@ use stacks::chainstate::coordinator::{
 };
 use stacks::chainstate::stacks::db::{ChainStateBootData, StacksChainState};
 use stacks::net::atlas::{AtlasConfig, AttachmentInstance};
+use tokio::sync::oneshot::Sender;
 
 use crate::run_loop::l1_observer;
 
@@ -280,12 +281,20 @@ impl RunLoop {
         &mut self,
         _burnchain_opt: Option<Burnchain>,
         coordinator_senders: CoordinatorChannels,
-    ) -> Box<dyn BurnchainController> {
+    ) -> (Box<dyn BurnchainController> , Option<Sender<()>>){
         // Initialize and start the burnchain.
         let mut burnchain_controller = self
             .config
             .make_burnchain_controller(coordinator_senders)
             .expect("couldn't create burnchain controller");
+
+
+        info!("Should we spawn warp server?: {}", self.config.burnchain.spawn_l1_observer());
+        let l1_observer_signal = if self.config.burnchain.spawn_l1_observer() {
+            Some(l1_observer::spawn(burnchain_controller.get_channel()))
+        } else {
+            None
+        };
 
         let burnchain_config = burnchain_controller.get_burnchain();
         let epochs = burnchain_controller.get_stacks_epochs();
@@ -338,7 +347,7 @@ impl RunLoop {
 
         // TODO (hack) instantiate the sortdb in the burnchain
         let _ = burnchain_controller.sortdb_mut();
-        burnchain_controller
+        (burnchain_controller,l1_observer_signal)
     }
 
     /// Instantiate the Stacks chain state and start the chains coordinator thread.
@@ -480,7 +489,7 @@ impl RunLoop {
             .expect("Run loop already started, can only start once after initialization.");
 
         self.setup_termination_handler();
-        let mut burnchain =
+        let (mut burnchain, l1_observer_signal) =
             self.instantiate_burnchain_state(burnchain_opt, coordinator_senders.clone());
 
         let burnchain_config = burnchain.get_burnchain();
@@ -512,14 +521,10 @@ impl RunLoop {
             coordinator_senders.clone(),
             attachments_rx,
         );
+
         let sortdb = burnchain.sortdb_mut();
         let mut sortition_db_height = RunLoop::get_sortition_db_height(&sortdb, &burnchain_config);
 
-        let l1_observer_signal = if self.config.burnchain.spawn_l1_observer() {
-            Some(l1_observer::spawn(burnchain.get_channel()))
-        } else {
-            None
-        };
 
         // Start the runloop
         debug!("Begin run loop");

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -289,7 +289,7 @@ impl RunLoop {
             .expect("couldn't create burnchain controller");
 
         info!(
-            "Should we spawn warp server?: {}",
+            "self.config.burnchain.spawn_l1_observer(): {}",
             self.config.burnchain.spawn_l1_observer()
         );
         let l1_observer_signal = if self.config.burnchain.spawn_l1_observer() {

--- a/testnet/stacks-node/src/run_loop/neon.rs
+++ b/testnet/stacks-node/src/run_loop/neon.rs
@@ -281,15 +281,17 @@ impl RunLoop {
         &mut self,
         _burnchain_opt: Option<Burnchain>,
         coordinator_senders: CoordinatorChannels,
-    ) -> (Box<dyn BurnchainController> , Option<Sender<()>>){
+    ) -> (Box<dyn BurnchainController>, Option<Sender<()>>) {
         // Initialize and start the burnchain.
         let mut burnchain_controller = self
             .config
             .make_burnchain_controller(coordinator_senders)
             .expect("couldn't create burnchain controller");
 
-
-        info!("Should we spawn warp server?: {}", self.config.burnchain.spawn_l1_observer());
+        info!(
+            "Should we spawn warp server?: {}",
+            self.config.burnchain.spawn_l1_observer()
+        );
         let l1_observer_signal = if self.config.burnchain.spawn_l1_observer() {
             Some(l1_observer::spawn(burnchain_controller.get_channel()))
         } else {
@@ -347,7 +349,7 @@ impl RunLoop {
 
         // TODO (hack) instantiate the sortdb in the burnchain
         let _ = burnchain_controller.sortdb_mut();
-        (burnchain_controller,l1_observer_signal)
+        (burnchain_controller, l1_observer_signal)
     }
 
     /// Instantiate the Stacks chain state and start the chains coordinator thread.
@@ -524,7 +526,6 @@ impl RunLoop {
 
         let sortdb = burnchain.sortdb_mut();
         let mut sortition_db_height = RunLoop::get_sortition_db_height(&sortdb, &burnchain_config);
-
 
         // Start the runloop
         debug!("Begin run loop");

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -1,15 +1,16 @@
 use std;
 use std::thread;
 
+use crate::burnchains::db_indexer::DBBurnchainIndexer;
 use crate::neon;
 use crate::tests::StacksL1Controller;
 use clarity::util::hash::to_hex;
 use rand::RngCore;
 use stacks::burnchains::Burnchain;
-use stacks::chainstate;
 use stacks::util::sleep_ms;
 use std::env;
 use std::time::Duration;
+use crate::stacks::burnchains::indexer::BurnchainIndexer;
 
 fn random_sortdb_test_dir() -> String {
     let mut rng = rand::thread_rng();
@@ -75,14 +76,14 @@ fn l1_observer_test() {
         }
     };
 
-    let tip = burndb
-        .get_canonical_chain_tip()
-        .expect("couldn't get chain tip");
-    info!("burnblock chain tip is {:?}", &tip);
+    let indexer = 
+        DBBurnchainIndexer::new(config.burnchain.clone(), false).
+        expect("Should be able to create DBBurnchainIndexer.");
+    let tip_height = indexer.get_highest_header_height().expect("Should have a highest block.");
 
     // Ensure that the tip height has moved beyond height 0.
     // We check that we have moved past 3 just to establish we are reliably getting blocks.
-    assert!(tip.block_height > 3);
+    assert!(tip_height > 3);
 
     channel.stop_chains_coordinator();
     stacks_l1_controller.kill_process();

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -3,6 +3,7 @@ use std::thread;
 
 use crate::burnchains::db_indexer::DBBurnchainIndexer;
 use crate::neon;
+use crate::stacks::burnchains::indexer::BurnchainIndexer;
 use crate::tests::StacksL1Controller;
 use clarity::util::hash::to_hex;
 use rand::RngCore;
@@ -10,7 +11,6 @@ use stacks::burnchains::Burnchain;
 use stacks::util::sleep_ms;
 use std::env;
 use std::time::Duration;
-use crate::stacks::burnchains::indexer::BurnchainIndexer;
 
 fn random_sortdb_test_dir() -> String {
     let mut rng = rand::thread_rng();
@@ -51,10 +51,11 @@ fn l1_observer_test() {
     // Sleep to give the run loop time to listen to blocks.
     thread::sleep(Duration::from_millis(45000));
 
-    let indexer = 
-        DBBurnchainIndexer::new(config.burnchain.clone(), false).
-        expect("Should be able to create DBBurnchainIndexer.");
-    let tip_height = indexer.get_highest_header_height().expect("Should have a highest block.");
+    let indexer = DBBurnchainIndexer::new(config.burnchain.clone(), false)
+        .expect("Should be able to create DBBurnchainIndexer.");
+    let tip_height = indexer
+        .get_highest_header_height()
+        .expect("Should have a highest block.");
 
     // Ensure that the tip height has moved beyond height 0.
     // We check that we have moved past 3 just to establish we are reliably getting blocks.

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -51,31 +51,6 @@ fn l1_observer_test() {
     // Sleep to give the run loop time to listen to blocks.
     thread::sleep(Duration::from_millis(45000));
 
-    // The burnchain should have registered what the listener recorded.
-    let burnchain = Burnchain::new(
-        &config.get_burn_db_path(),
-        &config.burnchain.chain,
-        &config.burnchain.mode,
-    )
-    .unwrap();
-
-    let burndb = loop {
-        match burnchain.open_db(true) {
-            Ok((_, burndb)) => {
-                break burndb;
-            }
-            Err(e) => {
-                match e {
-                    _ => {
-                        // continue
-                        info!("waiting for DB, {:?}", &e);
-                        sleep_ms(1000);
-                    }
-                }
-            }
-        }
-    };
-
     let indexer = 
         DBBurnchainIndexer::new(config.burnchain.clone(), false).
         expect("Should be able to create DBBurnchainIndexer.");

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -40,7 +40,6 @@ fn l1_observer_test() {
     let channel = run_loop.get_coordinator_channel().unwrap();
     thread::spawn(move || run_loop.start(None, 0));
 
-
     // Start Stacks L1.
     let l1_toml_file = "../../contrib/conf/stacks-l1-mocknet.toml";
     let mut stacks_l1_controller = StacksL1Controller::new(l1_toml_file.to_string(), true);

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -1,90 +1,19 @@
 use std;
-use std::process::{Child, Command, Stdio};
 use std::thread;
 
 use crate::neon;
+use crate::tests::StacksL1Controller;
+use clarity::util::hash::to_hex;
+use rand::RngCore;
 use stacks::burnchains::Burnchain;
 use std::env;
-use std::io::{BufRead, BufReader};
 use std::time::Duration;
 
-#[derive(std::fmt::Debug)]
-pub enum SubprocessError {
-    SpawnFailed(String),
-}
-
-type SubprocessResult<T> = Result<T, SubprocessError>;
-
-/// In charge of running L1 `stacks-node`.
-pub struct StacksL1Controller {
-    sub_process: Option<Child>,
-    config_path: String,
-    out_reader: Option<BufReader<std::process::ChildStdout>>,
-}
-
-impl StacksL1Controller {
-    pub fn new(config_path: String) -> StacksL1Controller {
-        StacksL1Controller {
-            sub_process: None,
-            config_path,
-            out_reader: None,
-        }
-    }
-
-    pub fn start_process(&mut self) -> SubprocessResult<()> {
-        let binary = match env::var("STACKS_BASE_DIR") {
-            Err(_) => {
-                // assume stacks-node is in path
-                "stacks-node".into()
-            }
-            Ok(path) => path,
-        };
-        let mut command = Command::new(&binary);
-        command
-            .stdout(Stdio::piped())
-            .arg("start")
-            .arg("--config=".to_owned() + &self.config_path);
-
-        info!("stacks-node mainchain spawn: {:?}", command);
-
-        let mut process = match command.spawn() {
-            Ok(child) => child,
-            Err(e) => return Err(SubprocessError::SpawnFailed(format!("{:?}", e))),
-        };
-
-        info!("stacks-node mainchain spawned, waiting for startup");
-        let mut out_reader = BufReader::new(process.stdout.take().unwrap());
-
-        let mut line = String::new();
-        while let Ok(bytes_read) = out_reader.read_line(&mut line) {
-            if bytes_read == 0 {
-                return Err(SubprocessError::SpawnFailed(
-                    "Stacks L1 closed before spawning network".into(),
-                ));
-            }
-            info!("{:?}", &line);
-            break;
-        }
-
-        info!("Stacks L1 startup finished");
-
-        self.sub_process = Some(process);
-        self.out_reader = Some(out_reader);
-
-        Ok(())
-    }
-
-    pub fn kill_process(&mut self) {
-        if let Some(mut sub_process) = self.sub_process.take() {
-            sub_process.kill().unwrap();
-        }
-    }
-}
-
-impl Drop for StacksL1Controller {
-    fn drop(&mut self) {
-        self.kill_process();
-    }
+fn random_sortdb_test_dir() -> String {
+    let mut rng = rand::thread_rng();
+    let mut buf = [0u8; 32];
+    rng.fill_bytes(&mut buf);
+    format!("/tmp/stacks-node-tests/sortdb/test-{}", to_hex(&buf))
 }
 
 /// This test brings up the Stacks-L1 chain in "mocknet" mode, and ensures that our listener can hear and record burn blocks
@@ -106,6 +35,12 @@ fn l1_observer_test() {
     let mut config = super::new_test_conf();
     config.burnchain.chain = "stacks_layer_1".to_string();
     config.burnchain.mode = "hyperchain".to_string();
+
+    let db_path_dir = random_sortdb_test_dir();
+    config.burnchain.indexer_base_db_path = db_path_dir;
+    config.burnchain.first_burn_header_hash =
+        "1111111111111111111111111111111111111111111111111111111111111111".to_string();
+
     let mut run_loop = neon::RunLoop::new(config.clone());
     let channel = run_loop.get_coordinator_channel().unwrap();
     thread::spawn(move || run_loop.start(None, 0));

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -26,13 +26,6 @@ fn l1_observer_test() {
         return;
     }
 
-    // Start Stacks L1.
-    let l1_toml_file = "../../contrib/conf/stacks-l1-mocknet.toml";
-    let mut stacks_l1_controller = StacksL1Controller::new(l1_toml_file.to_string(), true);
-    let _stacks_res = stacks_l1_controller
-        .start_process()
-        .expect("stacks l1 controller didn't start");
-
     // Start the L2 run loop.
     let mut config = super::new_test_conf();
     config.burnchain.chain = "stacks_layer_1".to_string();
@@ -41,11 +34,19 @@ fn l1_observer_test() {
     let db_path_dir = random_sortdb_test_dir();
     config.burnchain.indexer_base_db_path = db_path_dir;
     config.burnchain.first_burn_header_hash =
-        "1111111111111111111111111111111111111111111111111111111111111111".to_string();
+        "a7578f11a428bb953e7bbced9858525b6eec0d24d5d9d77285a7d7d891f68561".to_string();
 
     let mut run_loop = neon::RunLoop::new(config.clone());
     let channel = run_loop.get_coordinator_channel().unwrap();
     thread::spawn(move || run_loop.start(None, 0));
+
+
+    // Start Stacks L1.
+    let l1_toml_file = "../../contrib/conf/stacks-l1-mocknet.toml";
+    let mut stacks_l1_controller = StacksL1Controller::new(l1_toml_file.to_string(), true);
+    let _stacks_res = stacks_l1_controller
+        .start_process()
+        .expect("stacks l1 controller didn't start");
 
     // Sleep to give the run loop time to listen to blocks.
     thread::sleep(Duration::from_millis(45000));

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -497,7 +497,8 @@ impl StacksL1Controller {
                     // info!("in loop");
 
                     buffered_out.read_line(&mut buf).expect("reading a line didn't work");
-                    info!("L1: {}", &buf);
+                    info!("\x1b[0;33mL1: {}\x1b[0m", &buf);
+                    buf.clear();
 
                     // for line in buffered_out.lines() {
                     //     let line = match line {

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -496,7 +496,9 @@ impl StacksL1Controller {
                 loop {
                     // info!("in loop");
 
-                    buffered_out.read_line(&mut buf).expect("reading a line didn't work");
+                    buffered_out
+                        .read_line(&mut buf)
+                        .expect("reading a line didn't work");
                     info!("\x1b[0;33mL1: {}\x1b[0m", &buf);
                     buf.clear();
 

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -486,7 +486,6 @@ impl StacksL1Controller {
         };
 
         let printer_handle = if self.log_process {
-            info!("logging process");
             let child_out = process.stderr.take().unwrap();
             Some(thread::spawn(|| {
                 info!("spawned thread process");

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -494,21 +494,12 @@ impl StacksL1Controller {
                 let mut buffered_out = BufReader::new(child_out);
                 let mut buf = String::new();
                 loop {
-                    // info!("in loop");
-
                     buffered_out
                         .read_line(&mut buf)
                         .expect("reading a line didn't work");
+                    // Print the L1 log line in yellow.
                     info!("\x1b[0;33mL1: {}\x1b[0m", &buf);
                     buf.clear();
-
-                    // for line in buffered_out.lines() {
-                    //     let line = match line {
-                    //         Ok(x) => x,
-                    //         Err(e) => return,
-                    //     };
-                    //     println!("L1: {}", line);
-                    // }
                 }
             }))
         } else {


### PR DESCRIPTION
### Description
This PR contains edits to #50 that might be reviewed as a delta on their own.

Changes:
* `DBBurnchainIndexer` is set as the indexer for `L1Controller`. This can be the production set-up.
* This means that `tests::l1_observer_test::l1_observer_test` is now an end-to-end integration test exercising `DBBurnchainIndexer`.
* `DBBlockDownloader` is implemented by using `serde_json` to serialize the full `NewBlock` to the `headers` table.
* `StacksL1Controller` is modified to print out all the L1 output, and to do so in a yellow font.

### Applicable issues
- towards #43

### Additional info (benefits, drawbacks, caveats)
Still TBD:
* make use of `first_header_hash`
* unit tests for `sync_with_indexer`
* do we actually have a `bitcoin-tests.yml`?

### Checklist
- [x] Test coverage for new or modified code paths
- [ ] New integration test(s) added to `bitcoin-tests.yml`
