### PR TITLE
chore: Fix rust warnings

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -500,7 +500,7 @@ impl Burnchain {
         // Step 1: Check if we already have a block with this header. If so, make sure blocks
         // are the same, and short-circuit.
         match burnchain_db.get_burnchain_block(&block.header().block_hash) {
-            Ok(block_data) => {
+            Ok(_block_data) => {
                 return Ok(block.header());
             }
             Err(burnchain_error::UnknownBlock(_)) => {
@@ -802,9 +802,6 @@ impl Burnchain {
                     let mut last_processed = burn_chain_tip;
                     while let Ok(Some(burnchain_block)) = db_recv.recv() {
                         debug!("Try recv next parsed block"; "burnchain_block" => ?burnchain_block);
-
-                        let block_height = burnchain_block.block_height();
-
                         let insert_start = get_epoch_time_ms();
 
                         last_processed =

--- a/src/burnchains/test.rs
+++ b/src/burnchains/test.rs
@@ -49,7 +49,7 @@ impl Txid {
 }
 
 pub fn bhh_from_test_data(
-    mut block_height: u64,
+    block_height: u64,
     index_root: &TrieHash,
     noise: u64,
 ) -> BurnchainHeaderHash {

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -201,7 +201,7 @@ pub fn setup_states(
 
             // build a bunch of VRF key registers
 
-            let mut registers = vec![];
+            let registers = vec![];
 
             burn_block.replace((
                 burnchain_blocks_db,

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -1294,7 +1294,7 @@ mod test {
         let mut stacks_chain_tip = BlockSnapshot::initial(122, &BurnchainHeaderHash([3u8; 32]), 1);
         let sortition_chain_tip = BlockSnapshot::initial(122, &BurnchainHeaderHash([3u8; 32]), 2);
 
-        let mut block_commit = LeaderBlockCommitOp {
+        let block_commit = LeaderBlockCommitOp {
             block_header_hash: header.block_hash(),
             txid: Txid::from_bytes_be(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf")

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -5793,23 +5793,22 @@ impl StacksChainState {
         StacksChainState::can_admit_mempool_semantic(tx, is_mainnet)?;
 
         let conf = self.config();
-        let staging_height =
-            match self.get_stacks_block_height(current_consensus_hash, current_block) {
-                Ok(Some(height)) => height,
-                Ok(None) => {
-                    if *current_consensus_hash == FIRST_BURNCHAIN_CONSENSUS_HASH {
-                        0
-                    } else {
-                        return Err(MemPoolRejection::NoSuchChainTip(
-                            current_consensus_hash.clone(),
-                            current_block.clone(),
-                        ));
-                    }
+        match self.get_stacks_block_height(current_consensus_hash, current_block) {
+            Ok(Some(_height)) => (),
+            Ok(None) => {
+                if *current_consensus_hash == FIRST_BURNCHAIN_CONSENSUS_HASH {
+                    ()
+                } else {
+                    return Err(MemPoolRejection::NoSuchChainTip(
+                        current_consensus_hash.clone(),
+                        current_block.clone(),
+                    ));
                 }
-                Err(_e) => {
-                    panic!("DB CORRUPTION: failed to query block height");
-                }
-            };
+            }
+            Err(_e) => {
+                panic!("DB CORRUPTION: failed to query block height");
+            }
+        };
 
         let current_tip =
             StacksChainState::get_parent_index_block(current_consensus_hash, current_block);

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -5793,22 +5793,23 @@ impl StacksChainState {
         StacksChainState::can_admit_mempool_semantic(tx, is_mainnet)?;
 
         let conf = self.config();
-        match self.get_stacks_block_height(current_consensus_hash, current_block) {
-            Ok(Some(_height)) => (),
-            Ok(None) => {
-                if *current_consensus_hash == FIRST_BURNCHAIN_CONSENSUS_HASH {
-                    ()
-                } else {
-                    return Err(MemPoolRejection::NoSuchChainTip(
-                        current_consensus_hash.clone(),
-                        current_block.clone(),
-                    ));
+        let _staging_height =
+            match self.get_stacks_block_height(current_consensus_hash, current_block) {
+                Ok(Some(height)) => height,
+                Ok(None) => {
+                    if *current_consensus_hash == FIRST_BURNCHAIN_CONSENSUS_HASH {
+                        0
+                    } else {
+                        return Err(MemPoolRejection::NoSuchChainTip(
+                            current_consensus_hash.clone(),
+                            current_block.clone(),
+                        ));
+                    }
                 }
-            }
-            Err(_e) => {
-                panic!("DB CORRUPTION: failed to query block height");
-            }
-        };
+                Err(_e) => {
+                    panic!("DB CORRUPTION: failed to query block height");
+                }
+            };
 
         let current_tip =
             StacksChainState::get_parent_index_block(current_consensus_hash, current_block);

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -1394,7 +1394,6 @@ impl StacksChainState {
             }
 
             // Setup burnchain parameters for pox contract
-            let pox_constants = &boot_data.pox_constants;
             let contract = boot_code_id("pox", mainnet);
             let sender = PrincipalData::from(contract.clone());
             let params = vec![

--- a/src/chainstate/stacks/db/transactions.rs
+++ b/src/chainstate/stacks/db/transactions.rs
@@ -926,7 +926,7 @@ impl StacksChainState {
                 );
                 Ok(receipt)
             }
-            TransactionPayload::PoisonMicroblock(ref mblock_header_1, ref mblock_header_2) => {
+            TransactionPayload::PoisonMicroblock(ref _mblock_header_1, ref _mblock_header_2) => {
                 panic!("`TransactionPayload::PoisonMicroblock` case received, but poison microblocks are not supported in hyper-chains.")
             }
             TransactionPayload::Coinbase(_) => {

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -3067,8 +3067,7 @@ pub mod test {
             0,
         );
 
-        let mut first_burn_block =
-            TestStacksNode::next_burn_block(&mut burn_node.sortdb, &mut fork);
+        let first_burn_block = TestStacksNode::next_burn_block(&mut burn_node.sortdb, &mut fork);
 
         test_debug!("Mine {} initial transactions", first_burn_block.txs.len());
 

--- a/src/clarity_cli.rs
+++ b/src/clarity_cli.rs
@@ -764,11 +764,6 @@ fn install_boot_code<C: ClarityStorage>(header_db: &CLIHeadersDB, marf: &mut C) 
     // set up PoX
     let pox_contract = boot_code_id("pox", mainnet);
     let sender = PrincipalData::from(pox_contract.clone());
-    let pox_params = if mainnet {
-        PoxConstants::mainnet_default()
-    } else {
-        PoxConstants::testnet_default()
-    };
 
     let params = vec![
         SymbolicExpression::atom_value(Value::UInt(0)), // first burnchain block height

--- a/src/net/download.rs
+++ b/src/net/download.rs
@@ -1860,7 +1860,7 @@ impl PeerNetwork {
             test_debug!("{:?}: does NOT need blocks", &self.local_peer);
         }
 
-        PeerNetwork::with_downloader_state(self, |ref mut network, ref mut downloader| {
+        PeerNetwork::with_downloader_state(self, |ref mut _network, ref mut downloader| {
             let mut urlset = HashSet::new();
             for (_, requests) in downloader.blocks_to_try.iter() {
                 for request in requests.iter() {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2708,7 +2708,7 @@ pub mod test {
             );
             coord.handle_new_burnchain_block().unwrap();
 
-            let mut stacks_node = TestStacksNode::from_chainstate(chainstate);
+            let stacks_node = TestStacksNode::from_chainstate(chainstate);
 
             {
                 // pre-populate burnchain, if running on bitcoin
@@ -2722,7 +2722,7 @@ pub mod test {
                 for i in prev_snapshot.block_height..config.current_block {
                     let burn_block = {
                         let ic = sortdb.index_conn();
-                        let mut burn_block = fork.next_block(&ic);
+                        let burn_block = fork.next_block(&ic);
                         burn_block
                     };
                     fork.append_block(burn_block);
@@ -3359,7 +3359,7 @@ pub mod test {
                 parent_microblock_header_opt.as_ref(),
             );
 
-            let mut block_commit_op = stacks_node.make_tenure_commitment(
+            let block_commit_op = stacks_node.make_tenure_commitment(
                 &mut sortdb,
                 &mut burn_block,
                 &mut self.miner,

--- a/testnet/stacks-node/src/burnchains/l1_events.rs
+++ b/testnet/stacks-node/src/burnchains/l1_events.rs
@@ -36,7 +36,6 @@ use crate::{BurnchainController, BurnchainTip, Config};
 #[derive(Clone)]
 pub struct L1Channel {
     blocks: Arc<Mutex<Vec<NewBlock>>>,
-    minimum_recorded_height: Arc<Mutex<u64>>,
 }
 
 pub struct L1Controller {
@@ -51,10 +50,6 @@ pub struct L1Controller {
 
     coordinator: CoordinatorChannels,
     chain_tip: Option<BurnchainTip>,
-}
-
-pub struct L1BlockDownloader {
-    channel: Arc<L1Channel>,
 }
 
 /// Represents the returned JSON
@@ -77,7 +72,6 @@ impl L1Channel {
                 parent_index_block_hash: StacksBlockId::sentinel(),
                 events: vec![],
             }])),
-            minimum_recorded_height: Arc::new(Mutex::new(0)),
         }
     }
 }

--- a/testnet/stacks-node/src/burnchains/l1_events.rs
+++ b/testnet/stacks-node/src/burnchains/l1_events.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-use std::convert::TryInto;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -7,12 +5,8 @@ use std::time::Instant;
 use stacks::address::AddressHashMode;
 use stacks::burnchains::db::BurnchainDB;
 use stacks::burnchains::events::NewBlock;
-use stacks::burnchains::indexer::{
-    BurnBlockIPC, BurnchainBlockDownloader, BurnchainBlockParser, BurnchainIndexer,
-};
-use stacks::burnchains::{
-    Burnchain, BurnchainBlock, Error as BurnchainError, StacksHyperBlock, Txid,
-};
+use stacks::burnchains::indexer::BurnchainIndexer;
+use stacks::burnchains::{Burnchain, Error as BurnchainError, Txid};
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::operations::{BlockstackOperationType, LeaderBlockCommitOp};
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
@@ -34,9 +28,7 @@ use stacks::vm::types::QualifiedContractIdentifier;
 use stacks::vm::ClarityName;
 
 use super::db_indexer::DBBurnchainIndexer;
-use super::mock_events::BlockIPC;
 use super::{BurnchainChannel, Error};
-use crate::burnchains::mock_events::MockHeader;
 use crate::config::BurnchainConfig;
 use crate::operations::BurnchainOpSigner;
 use crate::{BurnchainController, BurnchainTip, Config};
@@ -109,70 +101,6 @@ impl BurnchainChannel for L1Channel {
         let mut blocks = self.blocks.lock().unwrap();
         blocks.push(new_block);
         Ok(())
-    }
-}
-
-impl L1Channel {
-    fn get_block(&self, fetch_height: u64) -> Option<NewBlock> {
-        let minimum_recorded_height = self.minimum_recorded_height.lock().unwrap();
-        let blocks = self.blocks.lock().unwrap();
-
-        let fetch_index = if fetch_height < *minimum_recorded_height {
-            return None;
-        } else {
-            (fetch_height - *minimum_recorded_height) as usize
-        };
-        if fetch_index >= blocks.len() {
-            return None;
-        }
-
-        let block = blocks[fetch_index].clone();
-        Some(block)
-    }
-
-    fn fill_blocks(
-        &self,
-        into: &mut Vec<NewBlock>,
-        start_block: u64,
-        end_block: Option<u64>,
-    ) -> Result<(), BurnchainError> {
-        let minimum_recorded_height = self.minimum_recorded_height.lock().unwrap();
-        let blocks = self.blocks.lock().unwrap();
-
-        if start_block < *minimum_recorded_height {
-            return Err(BurnchainError::DownloadError(
-                "Start block before downloader has mocked data".into(),
-            ));
-        }
-        let start_index = (start_block - *minimum_recorded_height) as usize;
-        if let Some(end_block) = end_block {
-            let end_index = std::cmp::min(
-                (1 + end_block - *minimum_recorded_height) as usize,
-                blocks.len(),
-            );
-            into.extend_from_slice(&blocks[start_index..end_index]);
-        } else {
-            into.extend_from_slice(&blocks[start_index..]);
-        }
-        Ok(())
-    }
-
-    fn highest_block(&self) -> u64 {
-        let minimum_recorded_height = self.minimum_recorded_height.lock().unwrap();
-        let blocks = self.blocks.lock().unwrap();
-
-        *minimum_recorded_height + (blocks.len() as u64) - 1
-    }
-}
-
-impl L1BlockDownloader {
-    fn fill_blocks(
-        &self,
-        into: &mut Vec<NewBlock>,
-        start_block: u64,
-        end_block: Option<u64>,
-    ) -> Result<(), BurnchainError> {
-        self.channel.fill_blocks(into, start_block, end_block)
     }
 }
 

--- a/testnet/stacks-node/src/burnchains/l1_events.rs
+++ b/testnet/stacks-node/src/burnchains/l1_events.rs
@@ -499,7 +499,7 @@ impl BurnchainController for L1Controller {
     }
 
     #[cfg(test)]
-    fn bootstrap_chain(&mut self, blocks_count: u64) {
+    fn bootstrap_chain(&mut self, _blocks_count: u64) {
         todo!()
     }
 }

--- a/testnet/stacks-node/src/burnchains/mock_events.rs
+++ b/testnet/stacks-node/src/burnchains/mock_events.rs
@@ -237,7 +237,9 @@ impl MockController {
 
         info!("Layer 1 block mined");
 
-        MOCK_EVENTS_STREAM.push_block(new_block);
+        MOCK_EVENTS_STREAM
+            .push_block(new_block)
+            .expect("`push_block` has failed.");
     }
 
     fn receive_blocks(

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -6,7 +6,6 @@ use std::time::Instant;
 
 use reqwest::Error as ReqwestError;
 use stacks::burnchains;
-use stacks::burnchains::events::NewBlock;
 use stacks::burnchains::indexer::BurnchainChannel;
 use stacks::burnchains::Burnchain;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;

--- a/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
@@ -455,10 +455,10 @@ fn test_db_sync_with_indexer_long_fork_repeated_calls() {
         };
 
     // Fork is:
-    // 1 -> 2 -> 3 -> 4 -> 5 -> 10
-    //   \-> 6 -> 7 -> 8 -> 9
+    // 1 -> 2 -> 3 -> 4 -> 9 -> 10
+    //   \-> 6 -> 7 -> 8 -> 5
     //
-    // Order is:
+    // Order added is:
     // 1, 2, 3, 6, 4, 7, 5, 8, 9, 10
     push_height_block_parent(1, 1, 0, 1, &"01".repeat(32));
     push_height_block_parent(2, 2, 1, 2, &"02".repeat(32));
@@ -466,10 +466,10 @@ fn test_db_sync_with_indexer_long_fork_repeated_calls() {
     push_height_block_parent(2, 6, 1, 3, &"03".repeat(32));
     push_height_block_parent(4, 4, 3, 4, &"04".repeat(32));
     push_height_block_parent(3, 7, 6, 4, &"04".repeat(32));
-    push_height_block_parent(5, 5, 4, 5, &"05".repeat(32));
-    push_height_block_parent(4, 8, 7, 5, &"05".repeat(32));
-    push_height_block_parent(5, 9, 8, 5, &"05".repeat(32));
-    push_height_block_parent(6, 10, 5, 6, &"0a".repeat(32));
+    push_height_block_parent(5, 9, 4, 5, &"09".repeat(32));
+    push_height_block_parent(4, 8, 7, 5, &"09".repeat(32));
+    push_height_block_parent(5, 5, 8, 5, &"05".repeat(32));
+    push_height_block_parent(6, 10, 9, 6, &"0a".repeat(32));
 }
 
 /// Test the DBBurnchainIndexer in the context of Burnchain::sync_with_indexer. Include
@@ -519,7 +519,7 @@ fn test_db_sync_with_indexer_long_fork_call_at_end() {
     // 1 -> 2 -> 3 -> 4 -> 5 -> 10
     //   \-> 6 -> 7 -> 8 -> 9
     //
-    // Order is:
+    // Order added is:
     // 1, 2, 3, 6, 4, 7, 5, 8, 9, 10
     push_height_block_parent(1, 1, 0);
     push_height_block_parent(2, 2, 1);

--- a/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
@@ -1,15 +1,10 @@
+use crate::burnchains::db_indexer::DBBurnchainIndexer;
 use crate::burnchains::l1_events::burnchain_from_config;
 use crate::burnchains::tests::{make_test_new_block, random_sortdb_test_dir};
 use crate::config::BurnchainConfig;
-use crate::{burnchains::db_indexer::DBBurnchainIndexer, rand::RngCore};
-use rand;
-use stacks::burnchains::events::{NewBlock, NewBlockTxEvent};
 use stacks::burnchains::indexer::BurnchainIndexer;
-use stacks::burnchains::Burnchain;
-use stacks::burnchains::Error as BurnchainError;
 use stacks::chainstate::coordinator::CoordinatorCommunication;
 use stacks::types::chainstate::{BurnchainHeaderHash, StacksBlockId};
-use stacks::util::hash::to_hex;
 
 /// Create config settings for the tests.
 fn make_test_config() -> BurnchainConfig {
@@ -27,7 +22,9 @@ fn make_test_config() -> BurnchainConfig {
 fn make_test_indexer() -> DBBurnchainIndexer {
     let mut indexer = DBBurnchainIndexer::new(&random_sortdb_test_dir(), make_test_config(), true)
         .expect("Couldn't create indexer.");
-    indexer.connect(true);
+    indexer
+        .connect(true)
+        .expect("Could not connect test indexer.");
     indexer
 }
 
@@ -164,7 +161,7 @@ fn test_detect_reorg() {
 fn test_sync_headers() {
     let mut indexer = make_test_indexer_add_10_block_branch();
 
-    /// No matter what the inputs, the answer is `10`, the max height.
+    // No matter what the inputs, the answer is `10`, the max height.
     assert_eq!(
         10,
         indexer
@@ -248,7 +245,7 @@ fn test_db_sync_with_indexer() {
 
     let mut burnchain =
         burnchain_from_config(&burnchain_dir, &config).expect("Could not create Burnchain.");
-    let (sortition_db, burn_db) = burnchain
+    let _ = burnchain
         .connect_db(
             &indexer,
             true,
@@ -309,7 +306,7 @@ fn test_db_sync_with_indexer_short_sequence() {
 
     let mut burnchain =
         burnchain_from_config(&burnchain_dir, &config).expect("Could not create Burnchain.");
-    let (sortition_db, burn_db) = burnchain
+    let (_sortition_db, burn_db) = burnchain
         .connect_db(
             &indexer,
             true,
@@ -407,7 +404,7 @@ fn test_db_sync_with_indexer_long_fork_repeated_calls() {
 
     let mut burnchain =
         burnchain_from_config(&burnchain_dir, &config).expect("Could not create Burnchain.");
-    let (sortition_db, burn_db) = burnchain
+    let (_sortition_db, burn_db) = burnchain
         .connect_db(
             &indexer,
             true,
@@ -491,7 +488,7 @@ fn test_db_sync_with_indexer_long_fork_call_at_end() {
 
     let mut burnchain =
         burnchain_from_config(&burnchain_dir, &config).expect("Could not create Burnchain.");
-    let (sortition_db, burn_db) = burnchain
+    let (_sortition_db, burn_db) = burnchain
         .connect_db(
             &indexer,
             true,

--- a/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
@@ -424,7 +424,11 @@ fn test_db_sync_with_indexer_long_fork_repeated_calls() {
 
     // Convenience method to push a block. Test the running chain tip against `expected_tip_height` and `expected_hash`.
     let mut push_height_block_parent =
-        |block_height: u64, block_idx: u8, parent_block_idx: u8, expected_tip_height: u64, expected_tip_hash:&str| {
+        |block_height: u64,
+         block_idx: u8,
+         parent_block_idx: u8,
+         expected_tip_height: u64,
+         expected_tip_hash: &str| {
             input_channel
                 .push_block(make_test_new_block(
                     block_height,

--- a/testnet/stacks-node/src/burnchains/tests/mod.rs
+++ b/testnet/stacks-node/src/burnchains/tests/mod.rs
@@ -1,17 +1,14 @@
 use crate::rand::RngCore;
-use stacks::burnchains::indexer::BurnBlockIPC;
 use stacks::vm::Value as ClarityValue;
 use stacks::{
     burnchains::{
         events::{ContractEvent, NewBlock, NewBlockTxEvent, TxEventType},
         Txid,
     },
-    types::chainstate::{BlockHeaderHash, BurnchainHeaderHash, StacksBlockId},
+    types::chainstate::StacksBlockId,
     util::hash::to_hex,
-    vm::types::{ContractIdentifier, QualifiedContractIdentifier, TupleData},
+    vm::types::{QualifiedContractIdentifier, TupleData},
 };
-
-use super::mock_events::BlockIPC;
 
 pub mod db_indexer;
 

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use rand::RngCore;
 
-use stacks::burnchains::{self, MagicBytes, BLOCKSTACK_MAGIC_MAINNET};
+use stacks::burnchains::{MagicBytes, BLOCKSTACK_MAGIC_MAINNET};
 use stacks::chainstate::coordinator::comm::CoordinatorChannels;
 use stacks::chainstate::stacks::miner::BlockBuilderSettings;
 use stacks::chainstate::stacks::StacksPrivateKey;

--- a/testnet/stacks-node/src/run_loop/l1_observer.rs
+++ b/testnet/stacks-node/src/run_loop/l1_observer.rs
@@ -72,10 +72,13 @@ async fn serve(
 /// Spawn a thread with a `warp` server.
 pub fn spawn(channel: Arc<dyn BurnchainChannel>) -> Sender<()> {
     let (signal_sender, signal_receiver) = oneshot::channel();
-    thread::Builder::new().name("l1-observer".into()).spawn(|| {
-        let rt = tokio::runtime::Runtime::new().expect("Failed to initialize tokio");
-        rt.block_on(serve(signal_receiver, channel))
-            .expect("block_on failed");
-    });
+    thread::Builder::new()
+        .name("l1-observer".into())
+        .spawn(|| {
+            let rt = tokio::runtime::Runtime::new().expect("Failed to initialize tokio");
+            rt.block_on(serve(signal_receiver, channel))
+                .expect("block_on failed");
+        })
+        .expect("`spawn` has failed.");
     signal_sender
 }


### PR DESCRIPTION
### Description
This PR should bring the number of warnings after #57 down to 0.

This is basically a mechanical change.

Testing:
* see no errors from `cargo check` or `cargo test` in either base level or `testnet/stacks-node`
* tested with existing tests

### Checklist
- [x] Test coverage for new or modified code paths
