### PR TITLE
fix: Wait for Stacks Blocks in Integration test

### DIFF
--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -2413,6 +2413,16 @@ impl SortitionDB {
         }
     }
 
+    /// Like `get_canonical_sortition_tip` but returns whole BlockSnapshot.
+    pub fn get_canonical_sortition_tip_snapshot(
+        conn: &Connection,
+    ) -> Result<Option<BlockSnapshot>, db_error> {
+        let qry = "SELECT * FROM snapshots WHERE pox_valid = 1 ORDER BY block_height DESC, burn_header_hash ASC LIMIT 1";
+        match query_row(conn, qry, NO_PARAMS) {
+            Ok(opt) => Ok(opt),
+            Err(e) => Err(db_error::from(e)),
+        }
+    }
     pub fn get_deposit_ft_ops(
         conn: &Connection,
         l1_block_id: &BurnchainHeaderHash,

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -2413,16 +2413,6 @@ impl SortitionDB {
         }
     }
 
-    /// Like `get_canonical_sortition_tip` but returns whole BlockSnapshot.
-    pub fn get_canonical_sortition_tip_snapshot(
-        conn: &Connection,
-    ) -> Result<Option<BlockSnapshot>, db_error> {
-        let qry = "SELECT * FROM snapshots WHERE pox_valid = 1 ORDER BY block_height DESC, burn_header_hash ASC LIMIT 1";
-        match query_row(conn, qry, NO_PARAMS) {
-            Ok(opt) => Ok(opt),
-            Err(e) => Err(db_error::from(e)),
-        }
-    }
     pub fn get_deposit_ft_ops(
         conn: &Connection,
         l1_block_id: &BurnchainHeaderHash,

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -113,8 +113,10 @@ impl Drop for StacksL1Controller {
     }
 }
 
+/// Longest time to wait for a stacks block before aborting.
 const PANIC_TIMEOUT_SECS: u64 = 600;
 
+/// Height of the current stacks tip.
 fn get_stacks_tip_height(sortition_db: &SortitionDB) -> i64 {
     let tip_snapshot = SortitionDB::get_canonical_sortition_tip_snapshot(&sortition_db.conn())
         .expect("Could not read from SortitionDB.");
@@ -125,6 +127,7 @@ fn get_stacks_tip_height(sortition_db: &SortitionDB) -> i64 {
     }
 }
 
+/// Wait for the *height* of the stacks chain tip to increment.
 pub fn next_block_and_wait(sortition_db: &SortitionDB) -> bool {
     let current = get_stacks_tip_height(sortition_db);
     let mut next = current;

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -128,7 +128,7 @@ fn get_stacks_tip_height(sortition_db: &SortitionDB) -> i64 {
 }
 
 /// Wait for the *height* of the stacks chain tip to increment.
-pub fn next_block_and_wait(sortition_db: &SortitionDB) -> bool {
+pub fn next_stacks_block_and_wait(sortition_db: &SortitionDB) -> bool {
     let current = get_stacks_tip_height(sortition_db);
     let mut next = current;
     eprintln!(
@@ -317,8 +317,8 @@ fn l1_integration_test() {
     println!("Submitted FT, NFT, and Hyperchain contracts!");
 
     // Wait for exactly two stacks blocks.
-    next_block_and_wait(&sortition_db);
-    next_block_and_wait(&sortition_db);
+    next_stacks_block_and_wait(&sortition_db);
+    next_stacks_block_and_wait(&sortition_db);
 
     // The burnchain should have registered what the listener recorded.
     let burnchain = Burnchain::new(

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -11,6 +11,7 @@ use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::stacks::StacksPrivateKey;
 use stacks::util::get_epoch_time_secs;
 use stacks::vm::types::QualifiedContractIdentifier;
+use std::convert::TryInto;
 use std::env;
 use std::io::{BufRead, BufReader};
 use std::time::{Duration, Instant};

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -261,7 +261,7 @@ fn l1_integration_test() {
         &config.burnchain.mode,
     )
     .unwrap();
-    let sortition_db = SortitionDB::open(&burnchain.get_db_path(), true).unwrap();
+    let (sortition_db, burndb) = burnchain.open_db(true).unwrap();
 
     let mut stacks_l1_controller = StacksL1Controller::new(l1_toml_file.to_string(), true);
     let _stacks_res = stacks_l1_controller
@@ -316,7 +316,6 @@ fn l1_integration_test() {
     wait_for_next_stacks_block(&sortition_db);
 
     // The burnchain should have registered what the listener recorded.
-    let (_, burndb) = burnchain.open_db(true).unwrap();
     let tip = burndb
         .get_canonical_chain_tip()
         .expect("couldn't get chain tip");

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -7,11 +7,13 @@ use crate::neon;
 use crate::tests::neon_integrations::{get_account, submit_tx};
 use crate::tests::{make_contract_publish, to_addr};
 use stacks::burnchains::Burnchain;
+use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::stacks::StacksPrivateKey;
+use stacks::util::get_epoch_time_secs;
 use stacks::vm::types::QualifiedContractIdentifier;
 use std::env;
 use std::io::{BufRead, BufReader};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[derive(std::fmt::Debug)]
 pub enum SubprocessError {
@@ -108,6 +110,40 @@ impl Drop for StacksL1Controller {
     fn drop(&mut self) {
         self.kill_process();
     }
+}
+
+const PANIC_TIMEOUT_SECS: u64 = 600;
+
+fn get_stacks_tip_height(sortition_db: &SortitionDB) -> i64 {
+    let tip_snapshot = SortitionDB::get_canonical_sortition_tip_snapshot(&sortition_db.conn())
+        .expect("Could not read from SortitionDB.");
+
+    match tip_snapshot {
+        Some(sn) => sn.stacks_block_height.try_into().unwrap(),
+        None => -1,
+    }
+}
+
+pub fn next_block_and_wait(sortition_db: &SortitionDB) -> bool {
+    let current = get_stacks_tip_height(sortition_db);
+    let mut next = current;
+    eprintln!(
+        "Issuing block at {}, waiting for bump ({})",
+        get_epoch_time_secs(),
+        current
+    );
+    let start = Instant::now();
+    while next <= current {
+        if start.elapsed() > Duration::from_secs(PANIC_TIMEOUT_SECS) {
+            error!("Timed out waiting for block to process, trying to continue test");
+            return false;
+        }
+        test_debug!("waiting for nex block, blocks_processed: {:?}", &next);
+        thread::sleep(Duration::from_millis(100));
+        next = get_stacks_tip_height(sortition_db);
+    }
+    eprintln!("Block bumped at {} ({})", get_epoch_time_secs(), next);
+    true
 }
 
 /// This test brings up the Stacks-L1 chain in "mocknet" mode, and ensures that our listener can hear and record burn blocks
@@ -218,6 +254,16 @@ fn l1_integration_test() {
     // Give the run loop time to start.
     thread::sleep(Duration::from_millis(2_000));
 
+    let sortition_db = {
+        let burnchain = Burnchain::new(
+            &config.get_burn_db_path(),
+            &config.burnchain.chain,
+            &config.burnchain.mode,
+        )
+        .unwrap();
+        SortitionDB::open(&burnchain.get_db_path(), true).unwrap()
+    };
+
     let mut stacks_l1_controller = StacksL1Controller::new(l1_toml_file.to_string(), true);
     let _stacks_res = stacks_l1_controller
         .start_process()
@@ -266,9 +312,9 @@ fn l1_integration_test() {
 
     println!("Submitted FT, NFT, and Hyperchain contracts!");
 
-    // Sleep to give the run loop time to listen to blocks,
-    //  and start mining L2 blocks
-    thread::sleep(Duration::from_secs(60));
+    // Wait for exactly two stacks blocks.
+    next_block_and_wait(&sortition_db);
+    next_block_and_wait(&sortition_db);
 
     // The burnchain should have registered what the listener recorded.
     let burnchain = Burnchain::new(


### PR DESCRIPTION
### Description

Adds `wait_for_next_stacks_block` to wait for the height of the *stacks* tip to increment.

Looks like `l1_integration_test` is passing reliably now.

### Applicable issues
- fixes #73

### Checklist
- [x] Test coverage for new or modified code paths

