### PR TITLE
feat: Don't allow "anchored block" forks

### DIFF
--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1101,8 +1101,6 @@ fn spawn_miner_relayer(
                             counters.bump_blocks_processed();
                         }
 
-                        info!("dev2: block produced: {:?}", &last_mined_block.anchored_block.block_hash());
-                        info!("dev: adding block_produced_at_burn_block; burn {:?} hash {:?}", &burn_header_hash, &last_mined_block.anchored_block.block_hash());
                         block_produced_at_burn_block.insert(burn_header_hash, last_mined_block.anchored_block.block_hash());
                         last_mined_blocks_vec.push((last_mined_block, microblock_privkey));
                     }


### PR DESCRIPTION
### Description
This PR adds bookkeeping to track the past Stacks blocks produced by a miner. This way, we can check whether the block the hyper-chain miner is building off is the last block it produced, on the given burnchain fork.

### Applicable issues
- fixes #66

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] Changelog is updated
- [ ] Required documentation changes (e.g., `docs/rpc/openapi.yaml` and `rpc-endpoints.md` for v2 endpoints, `event-dispatcher.md` for new events)
- [ ] New clarity functions have corresponding PR in `clarity-benchmarking` repo
- [ ] New integration test(s) added to `bitcoin-tests.yml`
