### PR TITLE
fix: More test reliability changes

### DIFF
--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -508,7 +508,8 @@ fn l2_simple_contract_calls() {
         submit_tx(&l2_rpc_origin, &small_contract_call1);
         wait_for_next_stacks_block(&sortition_db);
     }
-    // Wait an extra block to avoid flakes.
+    // Wait extra blocks to avoid flakes.
+    wait_for_next_stacks_block(&sortition_db);
     wait_for_next_stacks_block(&sortition_db);
 
     // Check for two calls to "return-one".

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -6,11 +6,6 @@ use crate::config::{EventKeyType, EventObserverConfig};
 use crate::neon;
 use crate::tests::neon_integrations::{get_account, submit_tx, test_observer};
 use crate::tests::{make_contract_call, make_contract_publish, to_addr};
-use stacks::burnchains::Burnchain;
-use stacks::chainstate::burn::db::sortdb::SortitionDB;
-use stacks::chainstate::stacks::{StacksPrivateKey, StacksTransaction, TransactionPayload};
-use stacks::codec::StacksMessageCodec;
-use stacks::util::hash::hex_bytes;
 use clarity::types::chainstate::StacksAddress;
 use clarity::util::get_epoch_time_secs;
 use clarity::vm::database::ClaritySerializable;
@@ -18,8 +13,13 @@ use clarity::vm::representations::ContractName;
 use clarity::vm::types::PrincipalData;
 use clarity::vm::Value;
 use reqwest::Response;
-use stacks::net::RPCPeerInfoData;
+use stacks::burnchains::Burnchain;
+use stacks::chainstate::burn::db::sortdb::SortitionDB;
+use stacks::chainstate::stacks::{StacksPrivateKey, StacksTransaction, TransactionPayload};
+use stacks::codec::StacksMessageCodec;
 use stacks::net::CallReadOnlyRequestBody;
+use stacks::net::RPCPeerInfoData;
+use stacks::util::hash::hex_bytes;
 use stacks::vm::types::QualifiedContractIdentifier;
 use stacks::vm::ClarityName;
 use std::convert::{TryFrom, TryInto};
@@ -408,7 +408,6 @@ fn l1_integration_test() {
     stacks_l1_controller.kill_process();
     run_loop_thread.join().expect("Failed to join run loop.");
 }
-
 
 #[test]
 fn l1_deposit_asset_integration_test() {

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -3,15 +3,18 @@ use std::process::{Child, Command, Stdio};
 use std::sync::atomic::Ordering;
 use std::thread::{self, JoinHandle};
 
+use crate::config::{EventKeyType, EventObserverConfig};
 use crate::neon;
-use crate::tests::neon_integrations::{get_account, submit_tx};
-use crate::tests::{make_contract_publish, to_addr};
+use crate::tests::neon_integrations::{get_account, submit_tx, test_observer};
+use crate::tests::{make_contract_call, make_contract_publish, to_addr};
 use stacks::burnchains::Burnchain;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
-use stacks::chainstate::stacks::StacksPrivateKey;
-use stacks::util::get_epoch_time_secs;
+use stacks::chainstate::stacks::{StacksPrivateKey, StacksTransaction, TransactionPayload};
+use stacks::codec::StacksMessageCodec;
+use stacks::util::hash::hex_bytes;
 use stacks::vm::types::QualifiedContractIdentifier;
-use std::convert::TryInto;
+use stacks::vm::{ClarityName, ContractName};
+use std::convert::{TryFrom, TryInto};
 use std::env;
 use std::io::{BufRead, BufReader};
 use std::time::{Duration, Instant};
@@ -121,30 +124,55 @@ fn get_stacks_tip_height(sortition_db: &SortitionDB) -> i64 {
     let tip_snapshot = SortitionDB::get_canonical_burn_chain_tip(&sortition_db.conn())
         .expect("Could not read from SortitionDB.");
 
-    tip_snapshot.stacks_block_height.try_into().unwrap()
+    tip_snapshot.canonical_stacks_tip_height.try_into().unwrap()
 }
 
 /// Wait for the *height* of the stacks chain tip to increment.
 pub fn wait_for_next_stacks_block(sortition_db: &SortitionDB) -> bool {
     let current = get_stacks_tip_height(sortition_db);
     let mut next = current;
-    eprintln!(
-        "Issuing block at {}, waiting for bump ({})",
-        get_epoch_time_secs(),
+    info!(
+        "wait_for_next_stacks_block: STARTS waiting at time {:?}, Stacks block height {:?}",
+        Instant::now(),
         current
     );
     let start = Instant::now();
     while next <= current {
         if start.elapsed() > Duration::from_secs(PANIC_TIMEOUT_SECS) {
-            error!("Timed out waiting for block to process, trying to continue test");
-            return false;
+            panic!("Timed out waiting for block to process, aborting test.");
         }
-        test_debug!("waiting for nex block, blocks_processed: {:?}", &next);
         thread::sleep(Duration::from_millis(100));
         next = get_stacks_tip_height(sortition_db);
     }
-    eprintln!("Block bumped at {} ({})", get_epoch_time_secs(), next);
+    info!(
+        "wait_for_next_stacks_block: STOPS waiting at time {:?}, Stacks block height {}",
+        Instant::now(),
+        next
+    );
     true
+}
+
+/// Deserializes the `StacksTransaction` objects from `blocks` and returns all those that
+/// match `test_fn`.
+fn select_transactions_where(
+    blocks: &Vec<serde_json::Value>,
+    test_fn: fn(&StacksTransaction) -> bool,
+) -> Vec<StacksTransaction> {
+    let mut result = vec![];
+    for block in blocks {
+        let transactions = block.get("transactions").unwrap().as_array().unwrap();
+        for tx in transactions.iter() {
+            let raw_tx = tx.get("raw_tx").unwrap().as_str().unwrap();
+            let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
+            let test_value = test_fn(&parsed);
+            if test_value {
+                result.push(parsed);
+            }
+        }
+    }
+
+    return result;
 }
 
 /// This test brings up the Stacks-L1 chain in "mocknet" mode, and ensures that our listener can hear and record burn blocks
@@ -335,6 +363,185 @@ fn l1_integration_test() {
         account.nonce >= 2,
         "Miner should have produced at least 2 coinbase transactions"
     );
+
+    termination_switch.store(false, Ordering::SeqCst);
+    stacks_l1_controller.kill_process();
+    run_loop_thread.join().expect("Failed to join run loop.");
+}
+
+/// Test that we can bring up an L2 node and make some simple calls to the L2 chain.
+#[test]
+fn l2_simple_contract_call() {
+    if env::var("STACKS_NODE_TEST") != Ok("1".into()) {
+        return;
+    }
+
+    // Start Stacks L1.
+    let l1_toml_file = "../../contrib/conf/stacks-l1-mocknet.toml";
+    let l1_rpc_origin = "http://127.0.0.1:20443";
+    let nft_trait_name = "nft-trait-standard";
+    let ft_trait_name = "ft-trait-standard";
+
+    // Start the L2 run loop.
+    let mut config = super::new_test_conf();
+    config.node.mining_key = Some(MOCKNET_PRIVATE_KEY_2.clone());
+    let miner_account = to_addr(&MOCKNET_PRIVATE_KEY_2);
+
+    config.burnchain.first_burn_header_hash =
+        "9946c68526249c259231f1660be4c72e915ebe1f25a8c8400095812b487eb279".to_string();
+    config.burnchain.first_burn_header_height = 1;
+    config.burnchain.chain = "stacks_layer_1".to_string();
+    config.burnchain.mode = "hyperchain".to_string();
+    config.burnchain.rpc_ssl = false;
+    config.burnchain.rpc_port = 20443;
+    config.burnchain.peer_host = "127.0.0.1".into();
+    config.node.wait_time_for_microblocks = 10_000;
+    config.node.rpc_bind = "127.0.0.1:30443".into();
+    config.node.p2p_bind = "127.0.0.1:30444".into();
+    let l2_rpc_origin = format!("http://{}", &config.node.rpc_bind);
+
+    config.burnchain.contract_identifier = QualifiedContractIdentifier::new(
+        to_addr(&MOCKNET_PRIVATE_KEY_1).into(),
+        "hyperchain-controller".into(),
+    );
+
+    config.node.miner = true;
+
+    let user_addr = to_addr(&MOCKNET_PRIVATE_KEY_1);
+    config.add_initial_balance(user_addr.to_string(), 10000000);
+
+    config.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    test_observer::spawn();
+
+    let event_observers: Vec<String> = config
+        .events_observers
+        .iter()
+        .map(|pair| pair.endpoint.clone())
+        .collect();
+    let mut run_loop = neon::RunLoop::new(config.clone());
+    let termination_switch = run_loop.get_termination_switch();
+    let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
+
+    // Give the run loop time to start.
+    thread::sleep(Duration::from_millis(2_000));
+
+    let burnchain = Burnchain::new(
+        &config.get_burn_db_path(),
+        &config.burnchain.chain,
+        &config.burnchain.mode,
+    )
+    .unwrap();
+    let (sortition_db, _) = burnchain.open_db(true).unwrap();
+
+    let mut stacks_l1_controller = StacksL1Controller::new(l1_toml_file.to_string(), true);
+    let _stacks_res = stacks_l1_controller
+        .start_process()
+        .expect("stacks l1 controller didn't start");
+
+    // Sleep to give the L1 chain time to start
+    thread::sleep(Duration::from_millis(10_000));
+
+    // Publish the NFT/FT traits
+    let ft_trait_content =
+        include_str!("../../../../core-contracts/contracts/helper/ft-trait-standard.clar");
+    let ft_trait_publish = make_contract_publish(
+        &MOCKNET_PRIVATE_KEY_1,
+        0,
+        1_000_000,
+        &ft_trait_name,
+        &ft_trait_content,
+    );
+    let nft_trait_content =
+        include_str!("../../../../core-contracts/contracts/helper/nft-trait-standard.clar");
+    let nft_trait_publish = make_contract_publish(
+        &MOCKNET_PRIVATE_KEY_1,
+        1,
+        1_000_000,
+        &nft_trait_name,
+        &nft_trait_content,
+    );
+
+    // Publish the default hyperchains contract on the L1 chain
+    let contract_content = include_str!("../../../../core-contracts/contracts/hyperchains.clar");
+    let hc_contract_publish = make_contract_publish(
+        &MOCKNET_PRIVATE_KEY_1,
+        2,
+        1_000_000,
+        config.burnchain.contract_identifier.name.as_str(),
+        &contract_content,
+    );
+
+    submit_tx(l1_rpc_origin, &ft_trait_publish);
+    submit_tx(l1_rpc_origin, &nft_trait_publish);
+    submit_tx(l1_rpc_origin, &hc_contract_publish);
+    println!("Submitted FT, NFT, and Hyperchain contracts!");
+
+    wait_for_next_stacks_block(&sortition_db);
+    wait_for_next_stacks_block(&sortition_db);
+
+    let small_contract = "(define-public (return-one) (ok 1))";
+    let mut l2_nonce = 0;
+    {
+        let hyperchain_small_contract_publish = make_contract_publish(
+            &MOCKNET_PRIVATE_KEY_1,
+            l2_nonce,
+            1000,
+            "small-contract",
+            small_contract,
+        );
+        l2_nonce += 1;
+        submit_tx(&l2_rpc_origin, &hyperchain_small_contract_publish);
+    }
+    wait_for_next_stacks_block(&sortition_db);
+    wait_for_next_stacks_block(&sortition_db);
+
+    {
+        let small_contract_call1 = make_contract_call(
+            &MOCKNET_PRIVATE_KEY_1,
+            l2_nonce,
+            1000,
+            &user_addr,
+            "small-contract",
+            "return-one",
+            &[],
+        );
+        l2_nonce += 1;
+        submit_tx(&l2_rpc_origin, &small_contract_call1);
+    }
+
+    wait_for_next_stacks_block(&sortition_db);
+    {
+        let small_contract_call1 = make_contract_call(
+            &MOCKNET_PRIVATE_KEY_1,
+            l2_nonce,
+            1000,
+            &user_addr,
+            "small-contract",
+            "return-one",
+            &[],
+        );
+        l2_nonce += 1;
+        submit_tx(&l2_rpc_origin, &small_contract_call1);
+    }
+    wait_for_next_stacks_block(&sortition_db);
+    wait_for_next_stacks_block(&sortition_db);
+
+    let small_contract_calls = select_transactions_where(
+        &test_observer::get_blocks(),
+        |transaction| match &transaction.payload {
+            TransactionPayload::ContractCall(contract) => {
+                contract.contract_name == ContractName::try_from("small-contract").unwrap()
+                    && contract.function_name == ClarityName::try_from("return-one").unwrap()
+            }
+            _ => false,
+        },
+    );
+
+    assert_eq!(small_contract_calls.len(), 2);
 
     termination_switch.store(false, Ordering::SeqCst);
     stacks_l1_controller.kill_process();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -70,7 +70,7 @@ pub mod test_observer {
 
     use crate::event_dispatcher::{MinedBlockEvent, MinedMicroblockEvent};
 
-    pub const EVENT_OBSERVER_PORT: u16 = 50303;
+    pub const EVENT_OBSERVER_PORT: u16 = 60303;
 
     lazy_static! {
         pub static ref NEW_BLOCKS: Mutex<Vec<serde_json::Value>> = Mutex::new(Vec::new());


### PR DESCRIPTION
### Description
Towards more reliable and precise tests:

1) Fix a bug in `wait_for_next_stacks_block` where we counted the stacks tip height incorrectly.
2) Start using the `test_observer` in L2 tests, so we can check which L2 blocks actually got produced.
3) Add a new L2 test `l2_simple_contract_calls` to check these above points, as well as exercise the system.

### Applicable issues
- fixes # 74

### Additional info (benefits, drawbacks, caveats)
Drawback: Still have to wait for "extra" stacks blocks, compared to what one would think, in order to avoid flakes. E.g., we have to wait 2 stacks blocks for 1 transaction to clear, probably so that it can propagate through the mempool. Would be nice to have a "wait for my transaction to hit the mempool" feature.

### Checklist
- [x] Test coverage for new or modified code paths
