### PR TITLE
Feat/add withdraw merkle tree

### DIFF
--- a/core-contracts/contracts/hyperchains.clar
+++ b/core-contracts/contracts/hyperchains.clar
@@ -71,19 +71,20 @@
 )
 
 ;; Helper function: modifies the block-commits map with a new commit and prints related info
-(define-private (inner-commit-block (block (buff 32)) (commit-block-height uint))
+;; TODO(60) store withdrawal-root in contract state
+(define-private (inner-commit-block (block (buff 32)) (commit-block-height uint) (withdrawal-root (buff 32)))
     (begin
         (map-set block-commits commit-block-height block)
-        (print { event: "block-commit", block-commit: block})
+        (print { event: "block-commit", block-commit: block, withdrawal-root: withdrawal-root})
         (ok block)
     )
 )
 
 ;; Subnets miners call this to commit a block at a particular height
-(define-public (commit-block (block (buff 32)))
+(define-public (commit-block (block (buff 32)) (withdrawal-root (buff 32)))
     (let ((commit-block-height block-height))
         (unwrap! (can-commit-block? commit-block-height) (err ERR_VALIDATION_FAILED))
-        (inner-commit-block block commit-block-height)
+        (inner-commit-block block commit-block-height withdrawal-root)
     )
 )
 

--- a/core-contracts/tests/hyperchains/hyperchains_test.ts
+++ b/core-contracts/tests/hyperchains/hyperchains_test.ts
@@ -17,12 +17,14 @@ Clarinet.test({
           Tx.contractCall("hyperchains", "commit-block",
                 [
                     types.buff(new Uint8Array([0, 1, 1, 1, 1])),
+                    types.buff(new Uint8Array([0, 1, 1, 1, 2])),
                 ],
                 alice.address),
           // Try and fail to commit a different block, but again at height 0.
           Tx.contractCall("hyperchains", "commit-block",
                 [
                     types.buff(new Uint8Array([0, 2, 2, 2, 2])),
+                    types.buff(new Uint8Array([0, 2, 2, 2, 3])),
                 ],
                 alice.address),
         ]);
@@ -40,6 +42,7 @@ Clarinet.test({
             Tx.contractCall("hyperchains", "commit-block",
                 [
                     types.buff(new Uint8Array([0, 2, 2, 2, 2])),
+                    types.buff(new Uint8Array([0, 2, 2, 2, 3])),
                 ],
                 bob.address),
         ]);
@@ -53,6 +56,7 @@ Clarinet.test({
             Tx.contractCall("hyperchains", "commit-block",
                 [
                     types.buff(new Uint8Array([0, 2, 2, 2, 2])),
+                    types.buff(new Uint8Array([0, 2, 2, 2, 3])),
                 ],
                 alice.address),
         ]);

--- a/src/burnchains/events.rs
+++ b/src/burnchains/events.rs
@@ -244,7 +244,9 @@ impl StacksHyperOp {
                     .get("withdrawal-root")
                     .map_err(|_| "No 'withdrawal-root' field in Clarity tuple")?;
                 let withdrawal_merkle_root =
-                    if let ClarityValue::Sequence(SequenceData::Buffer(buff_data)) = withdrawal_merkle_root {
+                    if let ClarityValue::Sequence(SequenceData::Buffer(buff_data)) =
+                        withdrawal_merkle_root
+                    {
                         if u32::from(buff_data.len()) != 32 {
                             Err(format!(
                                 "Expected 'withdrawal-root' type to be length 32, found {}",

--- a/src/burnchains/mod.rs
+++ b/src/burnchains/mod.rs
@@ -34,7 +34,7 @@ use chainstate::burn::ConsensusHash;
 use chainstate::stacks::StacksPublicKey;
 use core::*;
 use net::neighbors::MAX_NEIGHBOR_BLOCK_DELAY;
-use util::hash::Hash160;
+use util::hash::{Hash160, Sha512Trunc256Sum};
 use util::secp256k1::MessageSignature;
 use util_lib::db::Error as db_error;
 
@@ -202,6 +202,7 @@ pub struct BurnchainRecipient {
 pub enum StacksHyperOpType {
     BlockCommit {
         subnet_block_hash: BlockHeaderHash,
+        withdrawal_merkle_root: Sha512Trunc256Sum,
     },
     DepositStx {
         amount: u128,

--- a/src/burnchains/test.rs
+++ b/src/burnchains/test.rs
@@ -1276,7 +1276,7 @@ fn create_stacks_event_block_for_block_commit() {
                     ContractEvent {
                         contract_identifier: watched_contract.clone(),
                         topic: "print".into(),
-                        value: execute(r#"{ event: "block-commit", block-commit: 0x1234567890123456789012345678901212345678901234567890123456789012 }"#)
+                        value: execute(r#"{ event: "block-commit", block-commit: 0x1234567890123456789012345678901212345678901234567890123456789012, withdrawal-root: 0x1234567890123456789012345678901212345678901234567890123456789012 }"#)
                             .unwrap().unwrap(),
                     }
                 )
@@ -1291,7 +1291,7 @@ fn create_stacks_event_block_for_block_commit() {
                     ContractEvent {
                         contract_identifier: watched_contract.clone(),
                         topic: "print".into(),
-                        value: execute(r#"{ event: "block-commit", block-commit: 0x12345678901234567890123456789012 }"#)
+                        value: execute(r#"{ event: "block-commit", block-commit: 0x1234567890123456789012345678901212345678901234567890123456789012, withdrawal-root: 0x1234567890123456789012345678901212345678901234567890123456789012 }"#)
                             .unwrap().unwrap(),
                     }
                 )
@@ -1306,7 +1306,7 @@ fn create_stacks_event_block_for_block_commit() {
                     ContractEvent {
                         contract_identifier: ignored_contract.clone(),
                         topic: "print".into(),
-                        value: execute(r#"{ event: "block-commit", block-commit: 0x12345678901234567890123456789012 }"#)
+                        value: execute(r#"{ event: "block-commit", block-commit: 0x1234567890123456789012345678901212345678901234567890123456789012, withdrawal-root: 0x1234567890123456789012345678901212345678901234567890123456789012 }"#)
                             .unwrap().unwrap(),
                     }
                 )

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -390,6 +390,7 @@ mod tests {
 
         let block_commit = LeaderBlockCommitOp {
             block_header_hash: BlockHeaderHash([0x22; 32]),
+            withdrawal_merkle_root: Sha512Trunc256Sum([0x04; 32]),
             txid: Txid::from_bytes_be(
                 &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf")
                     .unwrap(),

--- a/src/chainstate/burn/db/sortdb.rs
+++ b/src/chainstate/burn/db/sortdb.rs
@@ -196,9 +196,11 @@ impl FromRow<LeaderBlockCommitOp> for LeaderBlockCommitOp {
         let txid = Txid::from_column(row, "txid")?;
         let burn_header_hash = BurnchainHeaderHash::from_column(row, "l1_block_id")?;
         let block_header_hash = BlockHeaderHash::from_column(row, "committed_block_hash")?;
+        let withdrawal_merkle_root = Sha512Trunc256Sum::from_column(row, "withdrawal_merkle_root")?;
 
         let block_commit = LeaderBlockCommitOp {
             block_header_hash,
+            withdrawal_merkle_root,
             txid,
             burn_header_hash,
         };
@@ -394,6 +396,7 @@ const SORTITION_DB_INITIAL_SCHEMA: &'static [&'static str] = &[
         txid TEXT NOT NULL,
         l1_block_id TEXT NOT NULL,
         committed_block_hash TEXT NOT NULL,
+        withdrawal_merkle_root TEXT NOT NULL,
         sortition_id TEXT NOT NULL,
 
         PRIMARY KEY(txid,sortition_id),
@@ -3089,12 +3092,13 @@ impl<'a> SortitionHandleTx<'a> {
             &block_commit.txid,
             &block_commit.burn_header_hash,
             &block_commit.block_header_hash,
+            &block_commit.withdrawal_merkle_root,
             sort_id,
         ];
 
         self.execute(
-            "INSERT INTO block_commits (txid, l1_block_id, committed_block_hash, sortition_id) \
-                      VALUES (?1, ?2, ?3, ?4)",
+            "INSERT INTO block_commits (txid, l1_block_id, committed_block_hash, withdrawal_merkle_root, sortition_id) \
+                      VALUES (?1, ?2, ?3, ?4, ?5)",
             args,
         )?;
 

--- a/src/chainstate/burn/db/tests.rs
+++ b/src/chainstate/burn/db/tests.rs
@@ -133,6 +133,7 @@ fn test_insert_block_commit() {
 
     let block_commit = LeaderBlockCommitOp {
         block_header_hash: BlockHeaderHash([0x22; 32]),
+        withdrawal_merkle_root: Sha512Trunc256Sum([0x04; 32]),
 
         txid: Txid::from_bytes_be(
             &hex_bytes("3c07a0a93360bc85047bbaadd49e30c8af770f73a37e10fec400174d2e5f27cf").unwrap(),

--- a/src/chainstate/burn/operations/leader_block_commit.rs
+++ b/src/chainstate/burn/operations/leader_block_commit.rs
@@ -42,7 +42,7 @@ use chainstate::stacks::{StacksPrivateKey, StacksPublicKey};
 use core::STACKS_EPOCH_2_05_MARKER;
 use core::{StacksEpoch, StacksEpochId};
 use net::Error as net_error;
-use util::hash::to_hex;
+use util::hash::{to_hex, Sha512Trunc256Sum};
 use util::log;
 use util::vrf::{VRFPrivateKey, VRFPublicKey, VRF};
 
@@ -67,10 +67,12 @@ impl TryFrom<&StacksHyperOp> for LeaderBlockCommitOp {
     fn try_from(value: &StacksHyperOp) -> Result<Self, Self::Error> {
         if let StacksHyperOpType::BlockCommit {
             ref subnet_block_hash,
+            ref withdrawal_merkle_root,
         } = value.event
         {
             Ok(LeaderBlockCommitOp {
                 block_header_hash: subnet_block_hash.clone(),
+                withdrawal_merkle_root: withdrawal_merkle_root.clone(),
                 txid: value.txid.clone(),
                 // use the StacksBlockId in the L1 event as the burnchain header hash
                 burn_header_hash: BurnchainHeaderHash(value.in_block.0.clone()),
@@ -86,6 +88,7 @@ impl LeaderBlockCommitOp {
     pub fn initial(block_header_hash: &BlockHeaderHash) -> LeaderBlockCommitOp {
         LeaderBlockCommitOp {
             block_header_hash: block_header_hash.clone(),
+            withdrawal_merkle_root: Sha512Trunc256Sum([0u8; 32]),
             // to be filled in
             txid: Txid([0u8; 32]),
             burn_header_hash: BurnchainHeaderHash::zero(),
@@ -96,6 +99,7 @@ impl LeaderBlockCommitOp {
     pub fn new(block_header_hash: &BlockHeaderHash) -> LeaderBlockCommitOp {
         LeaderBlockCommitOp {
             block_header_hash: block_header_hash.clone(),
+            withdrawal_merkle_root: Sha512Trunc256Sum([0u8; 32]),
             // to be filled in
             txid: Txid([0u8; 32]),
             burn_header_hash: BurnchainHeaderHash::zero(),

--- a/src/chainstate/burn/operations/mod.rs
+++ b/src/chainstate/burn/operations/mod.rs
@@ -214,6 +214,8 @@ pub struct PreStxOp {
 pub struct LeaderBlockCommitOp {
     /// Hash of the committed block (anchor block hash)
     pub block_header_hash: BlockHeaderHash,
+    /// Merkle root of the withdrawal events
+    pub withdrawal_merkle_root: Sha512Trunc256Sum,
     /// Transaction ID of this commit op
     pub txid: Txid,
     /// Hash of the base chain block that produced this commit op.

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -443,6 +443,7 @@ fn make_genesis_block_with_recipients(
 
     let commit_op = LeaderBlockCommitOp {
         block_header_hash: block.block_hash(),
+        withdrawal_merkle_root: block.header.withdrawal_merkle_root,
         txid: next_txid(),
         burn_header_hash: BurnchainHeaderHash([0; 32]),
     };
@@ -618,6 +619,7 @@ fn make_stacks_block_with_input(
 
     let commit_op = LeaderBlockCommitOp {
         block_header_hash: block.block_hash(),
+        withdrawal_merkle_root: block.header.withdrawal_merkle_root,
         txid: next_txid(),
         burn_header_hash: BurnchainHeaderHash([0; 32]),
     };

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -82,12 +82,12 @@ use crate::{types, util};
 use chainstate::stacks::address::StacksAddressExtensions;
 use chainstate::stacks::StacksBlockHeader;
 use chainstate::stacks::StacksMicroblockHeader;
+use clarity_vm::withdrawal::create_withdrawal_merkle_tree;
 use monitoring::set_last_execution_cost_observed;
 use rusqlite::types::ToSqlOutput;
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId};
 use types::chainstate::BurnchainHeaderHash;
 use util_lib::boot::boot_code_id;
-use clarity_vm::withdrawal::{create_withdrawal_merkle_tree};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StagingMicroblock {

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -87,6 +87,7 @@ use rusqlite::types::ToSqlOutput;
 use stacks_common::types::chainstate::{StacksAddress, StacksBlockId};
 use types::chainstate::BurnchainHeaderHash;
 use util_lib::boot::boot_code_id;
+use clarity_vm::withdrawal::{create_withdrawal_merkle_tree};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StagingMicroblock {
@@ -5288,6 +5289,9 @@ impl StacksChainState {
                 }
             }
 
+            tx_receipts.extend(microblock_txs_receipts.into_iter());
+
+            // check clarity state merkle root
             let root_hash = clarity_tx.get_root_hash();
             if root_hash != block.header.state_index_root {
                 let msg = format!(
@@ -5305,6 +5309,23 @@ impl StacksChainState {
             debug!("Reached state root {}", root_hash;
                    "microblock cost" => %microblock_execution_cost,
                    "block cost" => %block_cost);
+
+            // Check withdrawal state merkle root
+            // Process withdrawal events
+            let withdrawal_root_hash = create_withdrawal_merkle_tree(&tx_receipts);
+
+            if withdrawal_root_hash != block.header.withdrawal_merkle_root {
+                let msg = format!(
+                    "Block {} withdrawal root mismatch: expected {}, got {}",
+                    block.block_hash(),
+                    withdrawal_root_hash,
+                    block.header.withdrawal_merkle_root
+                );
+                warn!("{}", &msg);
+
+                clarity_tx.rollback_block();
+                return Err(Error::InvalidStacksBlock(msg));
+            }
 
             // good to go!
             clarity_tx.commit_to_block(chain_tip_consensus_hash, &block.block_hash());
@@ -5341,8 +5362,6 @@ impl StacksChainState {
                 total_coinbase,
             )
             .expect("FATAL: parsed and processed a block without a coinbase");
-
-            tx_receipts.extend(microblock_txs_receipts.into_iter());
 
             (
                 scheduled_miner_reward,
@@ -6364,6 +6383,7 @@ pub mod test {
             tx_merkle_root: Sha512Trunc256Sum([7u8; 32]),
             state_index_root: TrieHash([8u8; 32]),
             microblock_pubkey_hash: Hash160([9u8; 20]),
+            withdrawal_merkle_root: Sha512Trunc256Sum([10u8; 32]),
             miner_signatures: MessageSignatureList::empty(),
         };
 
@@ -6458,7 +6478,8 @@ pub mod test {
             parent_microblock_sequence: 4,
             tx_merkle_root: Sha512Trunc256Sum([7u8; 32]),
             state_index_root: TrieHash([8u8; 32]),
-            microblock_pubkey_hash: Hash160([9u8; 20]),
+            withdrawal_merkle_root: Sha512Trunc256Sum([9u8; 32]),
+            microblock_pubkey_hash: Hash160([10u8; 20]),
             miner_signatures: MessageSignatureList::empty(),
         };
 
@@ -7919,7 +7940,8 @@ pub mod test {
             parent_microblock_sequence: microblocks[num_mblocks - 1].header.sequence,
             tx_merkle_root: Sha512Trunc256Sum([7u8; 32]),
             state_index_root: TrieHash([8u8; 32]),
-            microblock_pubkey_hash: Hash160([9u8; 20]),
+            withdrawal_merkle_root: Sha512Trunc256Sum([9u8; 32]),
+            microblock_pubkey_hash: Hash160([10u8; 20]),
             miner_signatures: MessageSignatureList::empty(),
         };
 

--- a/src/chainstate/stacks/db/headers.rs
+++ b/src/chainstate/stacks/db/headers.rs
@@ -50,6 +50,7 @@ impl FromRow<StacksBlockHeader> for StacksBlockHeader {
         let parent_microblock_sequence: u16 = row.get_unwrap("parent_microblock_sequence");
         let tx_merkle_root = Sha512Trunc256Sum::from_column(row, "tx_merkle_root")?;
         let state_index_root = TrieHash::from_column(row, "state_index_root")?;
+        let withdrawal_merkle_root = Sha512Trunc256Sum::from_column(row, "withdrawal_merkle_root")?;
         let microblock_pubkey_hash = Hash160::from_column(row, "microblock_pubkey_hash")?;
 
         let block_hash = BlockHeaderHash::from_column(row, "block_hash")?;
@@ -74,6 +75,7 @@ impl FromRow<StacksBlockHeader> for StacksBlockHeader {
             parent_microblock_sequence,
             tx_merkle_root,
             state_index_root,
+            withdrawal_merkle_root,
             microblock_pubkey_hash,
             miner_signatures,
         };
@@ -155,6 +157,7 @@ impl StacksChainState {
             &header.parent_microblock_sequence,
             &header.tx_merkle_root,
             &header.state_index_root,
+            &header.withdrawal_merkle_root,
             &header.microblock_pubkey_hash,
             &block_hash,
             &index_block_hash,
@@ -180,6 +183,7 @@ impl StacksChainState {
                     parent_microblock_sequence, \
                     tx_merkle_root, \
                     state_index_root, \
+                    withdrawal_merkle_root, \
                     microblock_pubkey_hash, \
                     block_hash, \
                     index_block_hash, \
@@ -194,7 +198,7 @@ impl StacksChainState {
                     parent_block_id, \
                     miner_signatures \
                     ) \
-                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)", args)
+                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)", args)
             .map_err(|e| Error::DBError(db_error::SqliteError(e)))?;
 
         Ok(())

--- a/src/chainstate/stacks/db/mod.rs
+++ b/src/chainstate/stacks/db/mod.rs
@@ -579,6 +579,7 @@ const CHAINSTATE_INITIAL_SCHEMA: &'static [&'static str] = &[
         parent_microblock_sequence INTEGER NOT NULL,
         tx_merkle_root TEXT NOT NULL,
         state_index_root TEXT NOT NULL,
+        withdrawal_merkle_root TEXT NOT NULL,
         microblock_pubkey_hash TEXT NOT NULL,
         
         block_hash TEXT NOT NULL,                   -- NOTE: this is *not* unique, since two burn chain forks can commit to the same Stacks block.

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -57,8 +57,8 @@ use chainstate::stacks::address::StacksAddressExtensions;
 use chainstate::stacks::db::blocks::SetupBlockResult;
 use chainstate::stacks::StacksBlockHeader;
 use chainstate::stacks::StacksMicroblockHeader;
+use clarity_vm::withdrawal::create_withdrawal_merkle_tree;
 use vm::clarity::TransactionConnection;
-use clarity_vm::withdrawal::{create_withdrawal_merkle_tree};
 
 #[derive(Debug, Clone)]
 pub struct BlockBuilderSettings {

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -77,6 +77,7 @@ pub use stacks_common::address::{
     C32_ADDRESS_VERSION_MAINNET_MULTISIG, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
     C32_ADDRESS_VERSION_TESTNET_MULTISIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
+use chainstate::stacks::events::StacksTransactionReceipt;
 
 pub const STACKS_BLOCK_VERSION: u8 = 0;
 pub const STACKS_MICROBLOCK_VERSION: u8 = 0;
@@ -810,6 +811,7 @@ pub struct StacksBlockHeader {
     pub parent_microblock_sequence: u16,
     pub tx_merkle_root: Sha512Trunc256Sum,
     pub state_index_root: TrieHash,
+    pub withdrawal_merkle_root: Sha512Trunc256Sum,
     pub microblock_pubkey_hash: Hash160, // we'll get the public key back from the first signature (note that this is the Hash160 of the _compressed_ public key)
     /// Signatures of miners that have signed this block.
     pub miner_signatures: MessageSignatureList,
@@ -836,6 +838,7 @@ pub struct StacksBlockBuilder {
     pub chain_tip: StacksHeaderInfo,
     pub header: StacksBlockHeader,
     pub txs: Vec<StacksTransaction>,
+    pub tx_receipts: Vec<StacksTransactionReceipt>,
     pub micro_txs: Vec<StacksTransaction>,
     pub total_anchored_fees: u64,
     pub total_confirmed_streamed_fees: u64,
@@ -1260,6 +1263,7 @@ pub mod test {
             parent_microblock_sequence: 4,
             tx_merkle_root: tx_merkle_root,
             state_index_root: TrieHash([8u8; 32]),
+            withdrawal_merkle_root: Sha512Trunc256Sum([7u8; 32]),
             microblock_pubkey_hash: Hash160([9u8; 20]),
             miner_signatures: MessageSignatureList::empty(),
         };

--- a/src/chainstate/stacks/mod.rs
+++ b/src/chainstate/stacks/mod.rs
@@ -73,11 +73,11 @@ pub mod transaction;
 pub use types::chainstate::{StacksPrivateKey, StacksPublicKey};
 
 use chainstate::stacks::db::blocks::MessageSignatureList;
+use chainstate::stacks::events::StacksTransactionReceipt;
 pub use stacks_common::address::{
     C32_ADDRESS_VERSION_MAINNET_MULTISIG, C32_ADDRESS_VERSION_MAINNET_SINGLESIG,
     C32_ADDRESS_VERSION_TESTNET_MULTISIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
-use chainstate::stacks::events::StacksTransactionReceipt;
 
 pub const STACKS_BLOCK_VERSION: u8 = 0;
 pub const STACKS_MICROBLOCK_VERSION: u8 = 0;

--- a/src/clarity_vm/mod.rs
+++ b/src/clarity_vm/mod.rs
@@ -1,5 +1,6 @@
 /// High level interfaces for interacting with the Clarity vm
 pub mod clarity;
+pub mod withdrawal;
 
 pub mod special;
 
@@ -8,3 +9,4 @@ pub mod database;
 
 #[cfg(test)]
 mod tests;
+

--- a/src/clarity_vm/mod.rs
+++ b/src/clarity_vm/mod.rs
@@ -9,4 +9,3 @@ pub mod database;
 
 #[cfg(test)]
 mod tests;
-

--- a/src/clarity_vm/withdrawal.rs
+++ b/src/clarity_vm/withdrawal.rs
@@ -1,0 +1,69 @@
+use clarity_vm::database::marf::MarfedKV;
+use clarity::types::chainstate::{TrieHash, StacksBlockId, ConsensusHash, BlockHeaderHash};
+use clarity::vm::database::ClarityBackingStore;
+use chainstate::stacks::StacksBlockHeader;
+use chainstate::stacks::events::StacksTransactionReceipt;
+use clarity::vm::events::{StacksTransactionEvent, STXEventType, FTEventType, NFTWithdrawEventData, STXWithdrawEventData, NFTEventType};
+use vm::events::FTWithdrawEventData;
+use clarity::vm::types::PrincipalData;
+use clarity::util::hash::{Sha512Trunc256Sum, MerkleTree};
+use regex::internal::Input;
+
+pub fn make_key_for_withdrawal(data: String, sender: &PrincipalData, withdrawal_id: u32) -> String {
+    format!("withdrawal::{}::{}::{}", withdrawal_id, data, sender.to_string())
+}
+
+pub fn make_key_for_ft_withdrawal(data: &FTWithdrawEventData, withdrawal_id: u32) -> String {
+    let str_data = format!("{}::{}", data.asset_identifier, data.amount);
+    make_key_for_withdrawal(str_data, &data.sender, withdrawal_id)
+}
+
+pub fn make_key_for_nft_withdrawal(data: &NFTWithdrawEventData, withdrawal_id: u32) -> String {
+    let str_data = format!("{}", data.asset_identifier);
+    make_key_for_withdrawal(str_data, &data.sender, withdrawal_id)
+}
+
+pub fn make_key_for_stx_withdrawal(data: &STXWithdrawEventData, withdrawal_id: u32) -> String {
+    let str_data = format!("{}", data.amount);
+    make_key_for_withdrawal(str_data, &data.sender, withdrawal_id)
+}
+
+pub fn generate_withdrawal_keys(tx_receipts: &Vec<StacksTransactionReceipt>) -> Vec<Vec<u8>> {
+    let mut items = Vec::new();
+    let mut withdrawal_id = 0;
+    for receipt in tx_receipts {
+        for event in &receipt.events {
+            if let StacksTransactionEvent::NFTEvent(NFTEventType::NFTWithdrawEvent(data)) = event {
+                let key = make_key_for_nft_withdrawal(data, withdrawal_id);
+                withdrawal_id += 1;
+                items.push(key);
+            } else if let StacksTransactionEvent::FTEvent(FTEventType::FTWithdrawEvent(data)) = event {
+                let key = make_key_for_ft_withdrawal(data, withdrawal_id);
+                withdrawal_id += 1;
+                items.push(key);
+            } else if let StacksTransactionEvent::STXEvent(STXEventType::STXWithdrawEvent(data)) = event {
+                let key = make_key_for_stx_withdrawal(data, withdrawal_id);
+                withdrawal_id += 1;
+                items.push(key);
+            }
+        }
+
+    }
+    // Sort items before converting them to a byte vector to be inserted into a Merkle tree.
+    items.sort();
+
+    items.iter().map(|item| item.as_bytes().to_vec()).collect()
+}
+
+/// Put all withdrawal keys and values into a single Merkle tree
+/// The order of the transaction receipts will affect the final tree
+pub fn create_withdrawal_merkle_tree(
+    tx_receipts: &Vec<StacksTransactionReceipt>
+) -> Sha512Trunc256Sum {
+    let items = generate_withdrawal_keys(tx_receipts);
+
+    let merkle_tree = MerkleTree::<Sha512Trunc256Sum>::new(&items);
+    let tx_merkle_root = merkle_tree.root();
+
+    tx_merkle_root
+}

--- a/src/core/tests/mod.rs
+++ b/src/core/tests/mod.rs
@@ -117,6 +117,7 @@ fn make_block(
         parent_microblock_sequence: 0,
         tx_merkle_root: Sha512Trunc256Sum::empty(),
         state_index_root: TrieHash::from_empty_data(),
+        withdrawal_merkle_root: Sha512Trunc256Sum::empty(),
         microblock_pubkey_hash: Hash160([0; 20]),
         miner_signatures: MessageSignatureList::empty(),
     };

--- a/src/cost_estimates/tests/common.rs
+++ b/src/cost_estimates/tests/common.rs
@@ -28,6 +28,7 @@ pub fn make_block_receipt(tx_receipts: Vec<StacksTransactionReceipt>) -> StacksE
                 parent_microblock_sequence: 0,
                 tx_merkle_root: Sha512Trunc256Sum([0; 32]),
                 state_index_root: TrieHash([0; 32]),
+                withdrawal_merkle_root: Sha512Trunc256Sum([0; 32]),
                 microblock_pubkey_hash: Hash160([0; 20]),
                 miner_signatures: MessageSignatureList::empty(),
             },

--- a/testnet/stacks-node/src/burnchains/l1_events.rs
+++ b/testnet/stacks-node/src/burnchains/l1_events.rs
@@ -31,8 +31,8 @@ use super::db_indexer::DBBurnchainIndexer;
 use super::{BurnchainChannel, Error};
 use crate::config::BurnchainConfig;
 use crate::operations::BurnchainOpSigner;
-use crate::{BurnchainController, BurnchainTip, Config};
 use crate::util::hash::Sha512Trunc256Sum;
+use crate::{BurnchainController, BurnchainTip, Config};
 
 #[derive(Clone)]
 pub struct L1Channel {
@@ -270,7 +270,7 @@ impl L1Controller {
         sender_nonce: u64,
         tx_fee: u64,
         commit_to: BlockHeaderHash,
-        withdrawal_root: Sha512Trunc256Sum
+        withdrawal_root: Sha512Trunc256Sum,
     ) -> Result<StacksTransaction, Error> {
         let QualifiedContractIdentifier {
             issuer: contract_addr,
@@ -289,7 +289,7 @@ impl L1Controller {
             function_name: ClarityName::from("commit-block"),
             function_args: vec![
                 ClarityValue::buff_from(committed_block).map_err(|_| Error::BadCommitment)?,
-                ClarityValue::buff_from(withdrawal_root_bytes).map_err(|_| Error::BadCommitment)?
+                ClarityValue::buff_from(withdrawal_root_bytes).map_err(|_| Error::BadCommitment)?,
             ],
         };
 
@@ -341,7 +341,7 @@ impl L1Controller {
             nonce,
             fee,
             op.block_header_hash,
-            op.withdrawal_merkle_root
+            op.withdrawal_merkle_root,
         ) {
             Ok(x) => x,
             Err(e) => {

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1592,6 +1592,7 @@ pub enum EventKeyType {
     SmartContractEvent((QualifiedContractIdentifier, String)),
     AssetEvent(AssetIdentifier),
     STXEvent,
+    WithdrawalEvent,
     MemPoolTransactions,
     Microblocks,
     AnyEvent,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -59,6 +59,7 @@ use crate::run_loop::neon::RunLoop;
 use super::{BurnchainTip, Config, EventDispatcher, Keychain};
 use crate::stacks::vm::database::BurnStateDB;
 use stacks::monitoring;
+use crate::util::hash::Sha512Trunc256Sum;
 
 pub const RELAYER_MAX_BUFFER: usize = 100;
 
@@ -237,9 +238,10 @@ fn inner_generate_poison_microblock_tx(
 }
 
 /// Constructs and returns a LeaderBlockCommitOp out of the provided params
-fn inner_generate_block_commit_op(block_header_hash: BlockHeaderHash) -> BlockstackOperationType {
+fn inner_generate_block_commit_op(block_header_hash: BlockHeaderHash, withdrawal_merkle_root: Sha512Trunc256Sum) -> BlockstackOperationType {
     BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
         block_header_hash,
+        withdrawal_merkle_root,
         txid: Txid([0; 32]),
         burn_header_hash: BurnchainHeaderHash([0; 32]),
     })
@@ -1863,7 +1865,7 @@ impl StacksNode {
         );
 
         // let's commit
-        let op = inner_generate_block_commit_op(anchored_block.block_hash());
+        let op = inner_generate_block_commit_op(anchored_block.block_hash(), anchored_block.header.withdrawal_merkle_root);
 
         let cur_burn_chain_tip = SortitionDB::get_canonical_burn_chain_tip(burn_db.conn())
             .expect("FATAL: failed to query sortition DB for canonical burn chain tip");

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -58,8 +58,8 @@ use crate::run_loop::neon::RunLoop;
 
 use super::{BurnchainTip, Config, EventDispatcher, Keychain};
 use crate::stacks::vm::database::BurnStateDB;
-use stacks::monitoring;
 use crate::util::hash::Sha512Trunc256Sum;
+use stacks::monitoring;
 
 pub const RELAYER_MAX_BUFFER: usize = 100;
 
@@ -238,7 +238,10 @@ fn inner_generate_poison_microblock_tx(
 }
 
 /// Constructs and returns a LeaderBlockCommitOp out of the provided params
-fn inner_generate_block_commit_op(block_header_hash: BlockHeaderHash, withdrawal_merkle_root: Sha512Trunc256Sum) -> BlockstackOperationType {
+fn inner_generate_block_commit_op(
+    block_header_hash: BlockHeaderHash,
+    withdrawal_merkle_root: Sha512Trunc256Sum,
+) -> BlockstackOperationType {
     BlockstackOperationType::LeaderBlockCommit(LeaderBlockCommitOp {
         block_header_hash,
         withdrawal_merkle_root,
@@ -1865,7 +1868,10 @@ impl StacksNode {
         );
 
         // let's commit
-        let op = inner_generate_block_commit_op(anchored_block.block_hash(), anchored_block.header.withdrawal_merkle_root);
+        let op = inner_generate_block_commit_op(
+            anchored_block.block_hash(),
+            anchored_block.header.withdrawal_merkle_root,
+        );
 
         let cur_burn_chain_tip = SortitionDB::get_canonical_burn_chain_tip(burn_db.conn())
             .expect("FATAL: failed to query sortition DB for canonical burn chain tip");


### PR DESCRIPTION
<!--
  IMPORTANT
  Pull requests are ideal for making small changes to this project. However, they are NOT an appropriate venue to introducing non-trivial or breaking changes to the codebase.

  For introducing non-trivial or breaking changes to the codebase, please follow the SIP (Stacks Improvement Proposal) process documented here:
  https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md.
-->

### Description
Each hyperchains block will now generate a merkle tree of confirmed withdrawal events. The root hash of this merkle tree will be published along with the block commit. 

This root hash will be used by the hyperchains contract to validate withdrawal requests. 

### Applicable issues
- fixes part of #60  

### Additional info (benefits, drawbacks, caveats)

### Checklist
Will add integration test once L1 contract parsing is completed since implementation details might need to change to make the hash verification Clarity1 friendly. 
