### PR TITLE
Feat: Add forking integration test

### DIFF
--- a/testnet/stacks-node/src/burnchains/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/db_indexer.rs
@@ -236,7 +236,7 @@ impl BurnchainChannel for DBBurnBlockInputChannel {
         // In order to record this block, we either: 1) have already started recording, or 2) this
         // block has the "first hash" we're looking for.
         if current_canonical_tip_opt.is_none() {
-            if header.header_hash != self.first_burn_header_hash {
+            if header.parent_header_hash != self.first_burn_header_hash {
                 return Ok(());
             }
         }

--- a/testnet/stacks-node/src/burnchains/l1_events.rs
+++ b/testnet/stacks-node/src/burnchains/l1_events.rs
@@ -28,7 +28,7 @@ use stacks::vm::types::QualifiedContractIdentifier;
 use stacks::vm::ClarityName;
 
 use super::db_indexer::DBBurnchainIndexer;
-use super::{BurnchainChannel, Error};
+use super::{burnchain_from_config, BurnchainChannel, Error};
 use crate::config::BurnchainConfig;
 use crate::operations::BurnchainOpSigner;
 use crate::{BurnchainController, BurnchainTip, Config};
@@ -96,24 +96,6 @@ impl BurnchainChannel for L1Channel {
         blocks.push(new_block);
         Ok(())
     }
-}
-
-/// Build a `Burnchain` from values in `config`. Call `Burnchain::new`, which sets defaults
-/// and then override the "first block" information using `config`.
-pub fn burnchain_from_config(
-    burn_db_path: &str,
-    config: &BurnchainConfig,
-) -> Result<Burnchain, BurnchainError> {
-    let mut burnchain = Burnchain::new(&burn_db_path, &config.chain, &config.mode)?;
-    burnchain.first_block_hash = BurnchainHeaderHash::from_hex(&config.first_burn_header_hash)
-        .expect(&format!(
-            "Could not parse BurnchainHeaderHash: {}",
-            &config.first_burn_header_hash
-        ));
-    burnchain.first_block_height = config.first_burn_header_height;
-    burnchain.first_block_timestamp = config.first_burn_header_timestamp as u32;
-
-    Ok(burnchain)
 }
 
 impl L1Controller {

--- a/testnet/stacks-node/src/burnchains/mock_events.rs
+++ b/testnet/stacks-node/src/burnchains/mock_events.rs
@@ -25,7 +25,6 @@ use stacks::util::sleep_ms;
 use stacks::vm::types::{QualifiedContractIdentifier, TupleData};
 use stacks::vm::Value as ClarityValue;
 
-use crate::burnchains::l1_events::burnchain_from_config;
 use crate::operations::BurnchainOpSigner;
 use crate::{BurnchainController, BurnchainTip, Config};
 

--- a/testnet/stacks-node/src/burnchains/mock_events.rs
+++ b/testnet/stacks-node/src/burnchains/mock_events.rs
@@ -25,6 +25,7 @@ use stacks::util::sleep_ms;
 use stacks::vm::types::{QualifiedContractIdentifier, TupleData};
 use stacks::vm::Value as ClarityValue;
 
+use crate::burnchains::l1_events::burnchain_from_config;
 use crate::operations::BurnchainOpSigner;
 use crate::{BurnchainController, BurnchainTip, Config};
 

--- a/testnet/stacks-node/src/burnchains/mock_events.rs
+++ b/testnet/stacks-node/src/burnchains/mock_events.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -27,7 +28,8 @@ use stacks::vm::Value as ClarityValue;
 use crate::operations::BurnchainOpSigner;
 use crate::{BurnchainController, BurnchainTip, Config};
 
-use super::{BurnchainChannel, Error};
+use super::db_indexer::DBBurnchainIndexer;
+use super::{burnchain_from_config, BurnchainChannel, Error};
 
 #[derive(Clone)]
 pub struct MockChannel {
@@ -38,9 +40,9 @@ pub struct MockChannel {
 pub struct MockController {
     /// This is the simulated contract identifier
     contract_identifier: QualifiedContractIdentifier,
-    burnchain: Option<Burnchain>,
+    burnchain: Burnchain,
     config: Config,
-    indexer: MockIndexer,
+    indexer: DBBurnchainIndexer,
 
     db: Option<SortitionDB>,
     burnchain_db: Option<BurnchainDB>,
@@ -53,6 +55,8 @@ pub struct MockController {
     /// This will be a unique number for the next burn block. Starts at 1
     next_burn_block: Arc<Mutex<u64>>,
     next_commit: Arc<Mutex<Option<BlockHeaderHash>>>,
+    burn_block_to_height: HashMap<u64, u64>,
+    burn_block_to_parent: HashMap<u64, u64>,
 }
 
 pub struct MockIndexer {
@@ -166,10 +170,18 @@ impl MockBlockDownloader {
 impl MockController {
     pub fn new(config: Config, coordinator: CoordinatorChannels) -> MockController {
         let contract_identifier = config.burnchain.contract_identifier.clone();
-        let indexer = MockIndexer::new(contract_identifier.clone());
+        let indexer = DBBurnchainIndexer::new(
+            &config.get_burnchain_path_str(),
+            config.burnchain.clone(),
+            true,
+        )
+        .expect("Failed to initialize DBBurnchainIndexer.");
+        let burnchain = burnchain_from_config(&config.get_burn_db_path(), &config.burnchain)
+            .expect("Creation of burnchain has failed.");
+
         MockController {
             contract_identifier,
-            burnchain: None,
+            burnchain,
             config,
             indexer,
             db: None,
@@ -179,13 +191,19 @@ impl MockController {
             chain_tip: None,
             next_burn_block: NEXT_BURN_BLOCK.clone(),
             next_commit: NEXT_COMMIT.clone(),
+            burn_block_to_height: HashMap::new(),
+            burn_block_to_parent: HashMap::new(),
         }
     }
 
     /// Produce the next mocked layer-1 block. If `next_commit` is staged,
     /// this mocked block will contain that commitment.
-    pub fn next_block(&mut self) {
-        let mut next_burn_block = self.next_burn_block.lock().unwrap();
+    ///
+    /// If `specify_parent` is set, use this as the parent, otherwise use `self.next_burn_block - 1`.
+    ///
+    /// Returns the index of the block created.
+    pub fn next_block(&mut self, specify_parent: Option<u64>) -> u64 {
+        let upcoming_burn_block = *self.next_burn_block.lock().unwrap();
         let mut next_commit = self.next_commit.lock().unwrap();
 
         let tx_event = next_commit.take().map(|next_commit| {
@@ -221,25 +239,45 @@ impl MockController {
             }
         });
 
-        let parent_index_block_hash = StacksBlockId(make_mock_byte_string(*next_burn_block - 1));
+        let effective_parent = match specify_parent {
+            Some(parent) => parent,
+            None => upcoming_burn_block - 1,
+        };
+        let parent_index_block_hash = { StacksBlockId(make_mock_byte_string(effective_parent)) };
 
-        let index_block_hash = StacksBlockId(make_mock_byte_string(*next_burn_block));
+        let parent_result = self.burn_block_to_height.get(&effective_parent);
+        let parent_block_height = match parent_result {
+            Some(parent_height) => *parent_height,
+            None => {
+                // The only node whose height has a default is 0.
+                assert_eq!(0, effective_parent);
+                0
+            }
+        };
+        let block_height = parent_block_height + 1;
+
+        let index_block_hash = StacksBlockId(make_mock_byte_string(upcoming_burn_block));
 
         let new_block = NewBlock {
-            block_height: *next_burn_block,
-            burn_block_time: *next_burn_block,
+            block_height,
+            burn_block_time: upcoming_burn_block,
             index_block_hash,
             parent_index_block_hash,
             events: tx_event.into_iter().collect(),
         };
 
-        *next_burn_block += 1;
+        self.burn_block_to_height
+            .insert(upcoming_burn_block, block_height);
+        self.burn_block_to_parent
+            .insert(upcoming_burn_block, effective_parent);
 
-        info!("Layer 1 block mined");
-
-        MOCK_EVENTS_STREAM
+        self.indexer
+            .get_channel()
             .push_block(new_block)
             .expect("`push_block` has failed.");
+
+        *self.next_burn_block.lock().unwrap() += 1;
+        upcoming_burn_block
     }
 
     fn receive_blocks(
@@ -429,16 +467,7 @@ impl BurnchainController for MockController {
     }
 
     fn get_burnchain(&self) -> Burnchain {
-        match &self.burnchain {
-            Some(burnchain) => burnchain.clone(),
-            None => {
-                let working_dir = self.config.get_burn_db_path();
-                Burnchain::new(&working_dir, "mockstack", "hyperchain").unwrap_or_else(|e| {
-                    error!("Failed to instantiate burnchain: {}", e);
-                    panic!()
-                })
-            }
-        }
+        self.burnchain.clone()
     }
 
     fn wait_for_sortitions(&mut self, height_to_wait: Option<u64>) -> Result<BurnchainTip, Error> {

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -1,3 +1,5 @@
+use crate::config::BurnchainConfig;
+
 use super::operations::BurnchainOpSigner;
 
 use std::fmt;
@@ -12,6 +14,7 @@ use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::operations::BlockstackOperationType;
 use stacks::chainstate::burn::BlockSnapshot;
 use stacks::core::StacksEpoch;
+use stacks::types::chainstate::BurnchainHeaderHash;
 
 /// This module implements a burnchain controller that
 /// simulates the L1 chain. This controller accepts miner
@@ -174,4 +177,22 @@ impl BurnchainController for PanicController {
     ) -> Result<BurnchainTip, Error> {
         panic!()
     }
+}
+
+/// Build a `Burnchain` from values in `config`. Call `Burnchain::new`, which sets defaults
+/// and then override the "first block" information using `config`.
+pub fn burnchain_from_config(
+    burn_db_path: &str,
+    config: &BurnchainConfig,
+) -> Result<Burnchain, burnchains::Error> {
+    let mut burnchain = Burnchain::new(&burn_db_path, &config.chain, &config.mode)?;
+    burnchain.first_block_hash = BurnchainHeaderHash::from_hex(&config.first_burn_header_hash)
+        .expect(&format!(
+            "Could not parse BurnchainHeaderHash: {}",
+            &config.first_burn_header_hash
+        ));
+    burnchain.first_block_height = config.first_burn_header_height;
+    burnchain.first_block_timestamp = config.first_burn_header_timestamp as u32;
+
+    Ok(burnchain)
 }

--- a/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
@@ -1,5 +1,5 @@
+use crate::burnchains::burnchain_from_config;
 use crate::burnchains::db_indexer::DBBurnchainIndexer;
-use crate::burnchains::l1_events::burnchain_from_config;
 use crate::burnchains::tests::{make_test_new_block, random_sortdb_test_dir};
 use crate::config::BurnchainConfig;
 use stacks::burnchains::indexer::BurnchainIndexer;

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -2,9 +2,13 @@ use std;
 use std::process::{Child, Command, Stdio};
 use std::thread::{self, JoinHandle};
 
+use crate::burnchains::mock_events::MockController;
 use crate::config::{EventKeyType, EventObserverConfig};
 use crate::neon;
-use crate::tests::neon_integrations::{get_account, submit_tx, test_observer};
+use crate::tests::neon_integrations::{
+    get_account, mockstack_test_conf, next_block_and_wait, submit_tx, test_observer,
+    wait_for_runloop,
+};
 use crate::tests::{make_contract_call, make_contract_publish, to_addr};
 use clarity::types::chainstate::StacksAddress;
 use clarity::util::get_epoch_time_secs;
@@ -213,6 +217,40 @@ fn select_transactions_where(
     }
 
     return result;
+}
+
+/// Maps each block in `blocks` to its `burn_block_hash`.
+fn get_block_hashes(blocks: &Vec<serde_json::Value>) -> Vec<String> {
+    let mut result = vec![];
+    for block in blocks {
+        let burn_block_hash = block.get("burn_block_hash").unwrap().as_str().unwrap();
+        result.push(burn_block_hash.to_string());
+    }
+
+    return result;
+}
+
+/// Wait for `blocks_processed` to increment.
+pub fn wait_for_block(blocks_processed: &Arc<AtomicU64>) -> u64 {
+    let current = blocks_processed.load(Ordering::SeqCst);
+    info!(
+        "wait_for_block: Issuing block at {}, waiting for bump ({})",
+        get_epoch_time_secs(),
+        current
+    );
+    let start = Instant::now();
+    while blocks_processed.load(Ordering::SeqCst) <= current {
+        if start.elapsed() > Duration::from_secs(PANIC_TIMEOUT_SECS) {
+            panic!("Timed out waiting for block to process, trying to continue test");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    info!(
+        "wait_for_block: Block bumped at {} ({})",
+        get_epoch_time_secs(),
+        blocks_processed.load(Ordering::SeqCst)
+    );
+    0
 }
 
 /// This test brings up the Stacks-L1 chain in "mocknet" mode, and ensures that our listener can hear and record burn blocks
@@ -1077,5 +1115,89 @@ fn l2_simple_contract_calls() {
     assert_eq!(small_contract_calls.len(), 2);
     termination_switch.store(false, Ordering::SeqCst);
     stacks_l1_controller.kill_process();
+    run_loop_thread.join().expect("Failed to join run loop.");
+}
+
+/// Create burnchain fork, and see that the hyper-chain miner can continue to call.
+/// Does not exercise contract calls.
+#[test]
+fn no_contract_calls_forking_integration_test() {
+    let (mut conf, miner_account) = mockstack_test_conf();
+    let prom_bind = format!("{}:{}", "127.0.0.1", 6000);
+    conf.node.prometheus_bind = Some(prom_bind.clone());
+    conf.node.miner = true;
+
+    conf.burnchain.first_burn_header_hash =
+        "0000000000000001010101010101010101010101010101010101010101010101".to_string();
+    conf.burnchain.first_burn_header_height = 1;
+    conf.burnchain.first_burn_header_timestamp = 1;
+
+    let user_addr = to_addr(&MOCKNET_PRIVATE_KEY_1);
+    conf.add_initial_balance(user_addr.to_string(), 10000000);
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    test_observer::spawn();
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    let burnchain = Burnchain::new(
+        &conf.get_burn_db_path(),
+        &conf.burnchain.chain,
+        &conf.burnchain.mode,
+    )
+    .unwrap();
+
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+    let l2_rpc_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    let mut btc_regtest_controller = MockController::new(conf, channel.clone());
+
+    test_observer::spawn();
+    let termination_switch = run_loop.get_termination_switch();
+    let run_loop_thread = thread::spawn(move || run_loop.start(None, 0));
+
+    let common_ancestor = btc_regtest_controller.next_block(None);
+    wait_for_runloop(&blocks_processed);
+
+    let (sortition_db, burndb) = burnchain.open_db(true).unwrap();
+    {
+        let mut cursor = btc_regtest_controller.next_block(Some(common_ancestor));
+        for _ in 0..4 {
+            cursor = btc_regtest_controller.next_block(Some(cursor));
+            wait_for_block(&blocks_processed);
+        }
+        btc_regtest_controller.next_block(Some(cursor));
+    }
+    thread::sleep(Duration::from_millis(1000));
+
+    {
+        let mut cursor = btc_regtest_controller.next_block(Some(common_ancestor));
+        for _ in 0..6 {
+            cursor = btc_regtest_controller.next_block(Some(cursor));
+        }
+        wait_for_block(&blocks_processed);
+
+        thread::sleep(Duration::from_millis(1000));
+
+        for _ in 0..4 {
+            cursor = btc_regtest_controller.next_block(Some(cursor));
+            wait_for_block(&blocks_processed);
+        }
+        cursor = btc_regtest_controller.next_block(Some(cursor));
+    }
+    thread::sleep(Duration::from_millis(1000));
+
+    // We expect at least 8 blocks, because we have this many calls to `wait_for_block` followed
+    // by `next_block`.
+    // Note: We actually called `wait_for_block` 9 times, so why is this 8?
+    let blocks = test_observer::get_blocks();
+    assert!(blocks.len() >= 8);
+
+    termination_switch.store(false, Ordering::SeqCst);
     run_loop_thread.join().expect("Failed to join run loop.");
 }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -638,7 +638,7 @@ fn faucet_test() {
         "0000000000000000010101010101010101010101010101010101010101010101".to_string();
     conf.burnchain.first_burn_header_height = 0;
     conf.burnchain.first_burn_header_timestamp = 0;
-    
+
     let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
     let sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
     let sk_3 = StacksPrivateKey::from_hex(SK_3).unwrap();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -305,7 +305,7 @@ pub fn next_block_and_wait(
         get_epoch_time_secs(),
         current
     );
-    btc_controller.next_block();
+    btc_controller.next_block(None);
     let start = Instant::now();
     while blocks_processed.load(Ordering::SeqCst) <= current {
         if start.elapsed() > Duration::from_secs(PANIC_TIMEOUT_SECS) {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use stacks::burnchains::Burnchain;
+use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::ConsensusHash;
 use stacks::codec::StacksMessageCodec;
 use stacks::net::{AccountEntryResponse, ContractSrcResponse, RPCPeerInfoData};
@@ -23,7 +25,7 @@ use crate::tests::{
     make_contract_call, make_contract_publish, make_stacks_transfer, to_addr, SK_1, SK_2, SK_3,
 };
 use crate::{Config, ConfigFile, Keychain};
-
+use std::convert::TryInto;
 pub fn mockstack_test_conf() -> (Config, StacksAddress) {
     let mut conf = super::new_test_conf();
 
@@ -463,9 +465,9 @@ fn mockstack_integration_test() {
     let prom_bind = format!("{}:{}", "127.0.0.1", 6000);
     conf.node.prometheus_bind = Some(prom_bind.clone());
     conf.burnchain.first_burn_header_hash =
-        "0000000000000001010101010101010101010101010101010101010101010101".to_string();
-    conf.burnchain.first_burn_header_height = 1;
-    conf.burnchain.first_burn_header_timestamp = 1;
+        "0000000000000000010101010101010101010101010101010101010101010101".to_string();
+    conf.burnchain.first_burn_header_height = 0;
+    conf.burnchain.first_burn_header_timestamp = 0;
 
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 
@@ -632,7 +634,11 @@ const FAUCET_CONTRACT: &'static str = "
 #[test]
 fn faucet_test() {
     let (mut conf, miner_account) = mockstack_test_conf();
-
+    conf.burnchain.first_burn_header_hash =
+        "0000000000000000010101010101010101010101010101010101010101010101".to_string();
+    conf.burnchain.first_burn_header_height = 0;
+    conf.burnchain.first_burn_header_timestamp = 0;
+    
     let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
     let sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
     let sk_3 = StacksPrivateKey::from_hex(SK_3).unwrap();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -462,6 +462,10 @@ fn mockstack_integration_test() {
     let (mut conf, miner_account) = mockstack_test_conf();
     let prom_bind = format!("{}:{}", "127.0.0.1", 6000);
     conf.node.prometheus_bind = Some(prom_bind.clone());
+    conf.burnchain.first_burn_header_hash =
+        "0000000000000001010101010101010101010101010101010101010101010101".to_string();
+    conf.burnchain.first_burn_header_height = 1;
+    conf.burnchain.first_burn_header_timestamp = 1;
 
     let http_origin = format!("http://{}", &conf.node.rpc_bind);
 


### PR DESCRIPTION
### Description
This adds `no_contract_calls_forking_integration_test`, which creates a fork.

To support this, we added `DBBurnchainIndexer` as the indexer for `MockController`.

### Applicable issues
- towards #66

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [x] Test coverage for new or modified code paths

