### PR TITLE
Logging for potential manifestation of "off by 1" behavior

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -236,19 +236,37 @@ impl Burnchain {
     }
 
     pub fn reward_cycle_to_block_height(&self, reward_cycle: u64) -> u64 {
+        info!("reward_cycle: {:?}", &reward_cycle);
+        info!(
+            "self.pox_constants.reward_cycle_length: {:?}",
+            &self.pox_constants.reward_cycle_length
+        );
         // NOTE: the `+ 1` is because the height of the first block of a reward cycle is mod 1, not
         // mod 0.
-        self.first_block_height + reward_cycle * (self.pox_constants.reward_cycle_length as u64) + 1
+        let result = self.first_block_height
+            + reward_cycle * (self.pox_constants.reward_cycle_length as u64)
+            + 1;
+        info!("result: {:?}", &result);
+        result
     }
 
     pub fn block_height_to_reward_cycle(&self, block_height: u64) -> Option<u64> {
-        if block_height < self.first_block_height {
-            return None;
-        }
-        Some(
-            (block_height - self.first_block_height)
-                / (self.pox_constants.reward_cycle_length as u64),
-        )
+        info!("block_height: {:?}", &block_height);
+        info!("self.first_block_height: {:?}", &self.first_block_height);
+        info!(
+            "self.pox_constants.reward_cycle_length: {:?}",
+            &self.pox_constants.reward_cycle_length
+        );
+        let result = if block_height < self.first_block_height {
+            None
+        } else {
+            Some(
+                (block_height - self.first_block_height)
+                    / (self.pox_constants.reward_cycle_length as u64),
+            )
+        };
+        info!("result: {:?}", &result);
+        result
     }
 
     pub fn regtest(working_dir: &str) -> Burnchain {


### PR DESCRIPTION
I think there is a bug in the `RunLoop` when it starts. This is part of the "off by 1" behavior that pops up in various guises.

See attached filtered logs from running `mockstack_integration_test` with the logging in this PR.

In the logs we see

```
INFO [1652283162.535872] [testnet/stacks-node/src/run_loop/neon.rs:535] [ThreadId(3)] sortition_db_height: 2
INFO [1652283162.536625] [testnet/stacks-node/src/run_loop/neon.rs:537] [ThreadId(3)] block: [BlockSnapshot { block_height: 1, burn_header_timestamp: 0, burn_header_hash: 0000000000000000000000000000000000000000000000000000000000000001, parent_burn_header_hash: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, consensus_hash: 0000000000000000000000000000000000000000, ops_hash: 0000000000000000000000000000000000000000000000000000000000000000, total_burn: 0, sortition: true, sortition_hash: 0000000000000000000000000000000000000000000000000000000000000000, winning_block_txid: 0000000000000000000000000000000000000000000000000000000000000000, winning_stacks_block_hash: 0000000000000000000000000000000000000000000000000000000000000000, index_root: 5bd3f0165aa33131009996e9ce6976772be9a8a81761e0a3bd628325dd6eed0d, num_sortitions: 0, stacks_block_accepted: false, stacks_block_height: 0, arrival_index: 0, canonical_stacks_tip_height: 0, canonical_stacks_tip_hash: 0000000000000000000000000000000000000000000000000000000000000000, canonical_stacks_tip_consensus_hash: 0000000000000000000000000000000000000000, sortition_id: 0000000000000000000000000000000000000000000000000000000000000001, parent_sortition_id: 0000000000000000000000000000000000000000000000000000000000000001, pox_valid: true, accumulated_coinbase_ustx: 0 }]
```

That is, the code calculates the `sortition_db_height` as 2 but there is only one entry in the table.
[counting-bug.txt](https://github.com/hirosystems/stacks-hyperchains/files/8671384/counting-bug.txt)
