### PR TITLE
fix: use latest clarinet test lib 

### DIFF
--- a/core-contracts/tests/hyperchains/hyperchains_test.ts
+++ b/core-contracts/tests/hyperchains/hyperchains_test.ts
@@ -1,4 +1,4 @@
-import { Clarinet, Tx, Chain, Account, Contract, types } from 'https://deno.land/x/clarinet@v0.16.0/index.ts';
+import { Clarinet, Tx, Chain, Account, Contract, types } from 'https://deno.land/x/clarinet@v0.31.0/index.ts';
 import { assertEquals } from "https://deno.land/std@0.90.0/testing/asserts.ts";
 import { createHash } from "https://deno.land/std@0.107.0/hash/mod.ts";
 


### PR DESCRIPTION
### Description
Set clarinet version to `0.31.0`.

### Applicable issues
- fixes #100

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [x] Test coverage for new or modified code paths

