### PR TITLE
feat: wait M minutes before starting an anchored block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.21.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
+checksum = "ab7883017d5b21f011ef8040ea9c6c7ac90834c0df26a69e4c0b06276151f125"
 dependencies = [
  "secp256k1-sys",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7883017d5b21f011ef8040ea9c6c7ac90834c0df26a69e4c0b06276151f125"
+checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
 dependencies = [
  "secp256k1-sys",
  "serde",

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -1101,12 +1101,24 @@ pub struct NodeConfig {
     pub local_peer_seed: Vec<u8>,
     pub bootstrap_node: Vec<Neighbor>,
     pub deny_nodes: Vec<Neighbor>,
+    /// If true, this node is a miner, otherwise a follower.
     pub miner: bool,
+    /// If true, only do "mock mining", in which the miner doesn't actually send commitments.
+    /// Otherwise, if this is a miner, send commitments.
     pub mock_mining: bool,
+    /// If true, mine micro-blocks, otherwise don't.
     pub mine_microblocks: bool,
+    /// Try to mine a new micro-block every `microblock_frequency` milliseconds.
     pub microblock_frequency: u64,
+    /// The maximum number of micro-blocks this miner will try to make per burn block.
+    /// Note: This field is currently unused.
     pub max_microblocks: u64,
+    /// Wait this number of milliseconds: 1) before starting the first anchored block for a burn block,
+    /// and 2) before starting a new anchored block after another.
     pub wait_time_for_microblocks: u64,
+    /// Wait this amount of milliseconds, after learning of a new burn block, before starting on the first
+    /// anchored block for that burn block.
+    pub wait_before_first_anchored_block: u64,
     pub prometheus_bind: Option<String>,
     pub marf_cache_strategy: Option<String>,
     pub marf_defer_hashing: bool,
@@ -1403,6 +1415,7 @@ impl NodeConfig {
             microblock_frequency: 30_000,
             max_microblocks: u16::MAX as u64,
             wait_time_for_microblocks: 30_000,
+            wait_before_first_anchored_block: 5 * 60_000,
             prometheus_bind: None,
             marf_cache_strategy: None,
             marf_defer_hashing: true,

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1431,7 +1431,7 @@ impl StacksNode {
 
                 result
             };
-            info!(
+            debug!(
                 "relayer_issue_tenure: start_new_thread: {:?}",
                 &start_new_thread
             );

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -1,3 +1,4 @@
+use core::time;
 use std::cmp;
 use std::collections::{BTreeMap, HashMap};
 use std::collections::{HashSet, VecDeque};
@@ -100,6 +101,8 @@ pub struct StacksNode {
     pub atlas_config: AtlasConfig,
     pub p2p_thread_handle: JoinHandle<()>,
     pub relayer_thread_handle: JoinHandle<()>,
+    /// Includes the data for the next `RunTenure` directive. Once the "wait for micro-blocks" nap is over.
+    next_run_tenure_data: Arc<Mutex<Option<(BlockSnapshot, u128)>>>,
 }
 
 #[cfg(test)]
@@ -1081,6 +1084,10 @@ fn spawn_miner_relayer(
                         // stale request
                         continue;
                     }
+                    if last_mined_blocks.contains_key(&burnchain_tip.burn_header_hash) {
+                        // this miner has already made an anchored block for this burn block
+                        continue;
+                    }
                     if let Some(cur_sortition) = get_last_sortition(&last_sortition) {
                         if burnchain_tip.sortition_id != cur_sortition.sortition_id {
                             debug!("Drop stale RunMicroblockTenure for {}/{}: current sortition is for {} ({})", &burnchain_tip.consensus_hash, &burnchain_tip.winning_stacks_block_hash, &cur_sortition.consensus_hash, &cur_sortition.burn_header_hash);
@@ -1394,6 +1401,7 @@ impl StacksNode {
             atlas_config,
             p2p_thread_handle,
             relayer_thread_handle,
+            next_run_tenure_data: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -1406,17 +1414,71 @@ impl StacksNode {
         }
 
         if let Some(burnchain_tip) = get_last_sortition(&self.last_sortition) {
-            debug!(
-                "Tenure: Building off of {}",
-                &burnchain_tip.burn_header_hash
-            );
+            let relay_channel = self.relay_channel.clone();
+            let wait_before_first_anchored_block =
+                self.config.node.wait_before_first_anchored_block;
 
-            self.relay_channel
-                .send(RelayerDirective::RunTenure(
-                    burnchain_tip,
-                    get_epoch_time_ms(),
-                ))
-                .is_ok()
+            let start_new_thread = {
+                let mut next_run_tenure_data_mutex = self.next_run_tenure_data.lock().unwrap();
+
+                let result = match &*next_run_tenure_data_mutex {
+                    Some(_) => false,
+                    None => true,
+                };
+                *next_run_tenure_data_mutex = Some((burnchain_tip, get_epoch_time_ms()));
+
+                result
+            };
+
+            info!(
+                "relayer_issue_tenure: start_new_thread: {:?}",
+                &start_new_thread
+            );
+            if start_new_thread {
+                let next_run_tenure_data = self.next_run_tenure_data.clone();
+                thread::spawn(move || {
+                    debug!(
+                            "relayer_issue_tenure: Spawning a thread to wait {} ms and then build off of then-leading tip.",
+                            wait_before_first_anchored_block,
+                        );
+
+                    thread::sleep(time::Duration::from_millis(
+                        wait_before_first_anchored_block,
+                    ));
+
+                    let mut tenure_data_copy = next_run_tenure_data.lock().unwrap();
+                    match &*tenure_data_copy {
+                        Some(relay_tenure_data) => {
+                            debug!(
+                                "relayer_issue_tenure: Have waited {} ms and now will build off of {:?}",
+                                wait_before_first_anchored_block, &relay_tenure_data.0
+                            );
+
+                            // Send the signal.
+                            let result = relay_channel
+                                .send(RelayerDirective::RunTenure(
+                                    relay_tenure_data.0.clone(),
+                                    relay_tenure_data.1,
+                                ))
+                                .is_ok();
+
+                            // Reset the mutex.
+                            *tenure_data_copy = None;
+
+                            result
+                        }
+                        None => {
+                            debug!(
+                                "relayer_issue_tenure: Have waited {} but there is nothing to build off of any more.",
+                                wait_before_first_anchored_block,
+                            );
+                            true
+                        }
+                    }
+                });
+            }
+
+            true
         } else {
             warn!("Tenure: Do not know the last burn block. As a miner, this is bad.");
             true

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -534,10 +534,6 @@ fn l1_deposit_asset_integration_test() {
 
     println!("Submitted FT, NFT, and Hyperchain contracts!");
 
-    // Sleep to give the run loop time to listen to blocks,
-    //  and start mining L2 blocks
-    thread::sleep(Duration::from_secs(60));
-
     // The burnchain should have registered what the listener recorded.
     let burnchain = Burnchain::new(
         &config.get_burn_db_path(),
@@ -545,7 +541,9 @@ fn l1_deposit_asset_integration_test() {
         &config.burnchain.mode,
     )
     .unwrap();
-    let (_, burndb) = burnchain.open_db(true).unwrap();
+    let (sortition_db, burndb) = burnchain.open_db(true).unwrap();
+    wait_for_next_stacks_block(&sortition_db);
+    wait_for_next_stacks_block(&sortition_db);
     let tip = burndb
         .get_canonical_chain_tip()
         .expect("couldn't get chain tip");
@@ -648,8 +646,8 @@ fn l1_deposit_asset_integration_test() {
     submit_tx(l1_rpc_origin, &l1_mint_nft_tx);
     submit_tx(l1_rpc_origin, &hc_setup_tx);
 
-    // Sleep to give the run loop time to mine a block
-    thread::sleep(Duration::from_secs(30));
+    wait_for_next_stacks_block(&sortition_db);
+    wait_for_next_stacks_block(&sortition_db);
 
     // Check that the user does not own any of the fungible tokens on the hyperchain now
     let res = call_read_only(
@@ -713,8 +711,8 @@ fn l1_deposit_asset_integration_test() {
     // deposit nft-token into hyperchains contract on L1
     submit_tx(&l1_rpc_origin, &l1_deposit_nft_tx);
 
-    // Sleep to give the run loop time to mine a block
-    thread::sleep(Duration::from_secs(25));
+    wait_for_next_stacks_block(&sortition_db);
+    wait_for_next_stacks_block(&sortition_db);
 
     // Check that the user owns a fungible token on the hyperchain now
     let res = call_read_only(
@@ -806,7 +804,7 @@ fn l1_deposit_stx_integration_test() {
         &config.burnchain.mode,
     )
     .unwrap();
-    let (_, burndb) = burnchain.open_db(true).unwrap();
+    let (sortition_db, burndb) = burnchain.open_db(true).unwrap();
 
     let mut stacks_l1_controller = StacksL1Controller::new(l1_toml_file.to_string(), true);
     let _stacks_res = stacks_l1_controller
@@ -854,9 +852,8 @@ fn l1_deposit_stx_integration_test() {
     submit_tx(l1_rpc_origin, &nft_trait_publish);
     submit_tx(l1_rpc_origin, &hc_contract_publish);
 
-    // Sleep to give the run loop time to listen to blocks,
-    //  and start mining L2 blocks
-    thread::sleep(Duration::from_secs(60));
+    wait_for_next_stacks_block(&sortition_db);
+    wait_for_next_stacks_block(&sortition_db);
 
     // The burnchain should have registered what the listener recorded.
     let tip = burndb
@@ -888,8 +885,8 @@ fn l1_deposit_stx_integration_test() {
     l1_nonce += 1;
     submit_tx(l1_rpc_origin, &hc_setup_tx);
 
-    // Sleep to give the run loop time to listen to blocks
-    thread::sleep(Duration::from_secs(30));
+    wait_for_next_stacks_block(&sortition_db);
+    wait_for_next_stacks_block(&sortition_db);
 
     // Check that the user does not own any STX on the hyperchain now
     let account = get_account(&l2_rpc_origin, &user_addr);
@@ -909,8 +906,8 @@ fn l1_deposit_stx_integration_test() {
     // deposit stx into hyperchains contract on L1
     submit_tx(&l1_rpc_origin, &l1_deposit_stx_tx);
 
-    // Sleep to give the run loop time to mine a block
-    thread::sleep(Duration::from_secs(25));
+    wait_for_next_stacks_block(&sortition_db);
+    wait_for_next_stacks_block(&sortition_db);
 
     // Check that the user owns STX on the hyperchain now
     let account = get_account(&l2_rpc_origin, &user_addr);

--- a/testnet/stacks-node/src/tests/mod.rs
+++ b/testnet/stacks-node/src/tests/mod.rs
@@ -253,6 +253,9 @@ pub fn new_test_conf() -> Config {
     conf.node.p2p_bind = format!("{}:{}", localhost, p2p_port);
     conf.node.data_url = format!("https://{}:{}", localhost, rpc_port);
     conf.node.p2p_address = format!("{}:{}", localhost, p2p_port);
+
+    conf.node.wait_before_first_anchored_block = 1_000;
+
     conf
 }
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1009,6 +1009,9 @@ fn assert_l2_l1_tip_heights(sortition_db: &SortitionDB, l2_height: u64, l1_heigh
     assert_eq!(l1_height, tip_snapshot.block_height);
 }
 
+/// Test that we can make micro-blocks. The L2 chain is set to wait M seconds before
+/// making an anchored block. Send a transaction before this time is up and then sleep
+/// to see that this transaction went into a micro-block.
 #[test]
 #[ignore]
 fn micro_test() {
@@ -1214,6 +1217,7 @@ fn select_transactions_where(
     return result;
 }
 
+/// Sleep for `sleep_duration`, and log `reason` at beginning and end of sleep.
 fn sleep_for_reason(sleep_duration: Duration, reason: &str) {
     info!(
         "sleep_for_reason: START sleep {:?} for reason: {}",
@@ -1228,6 +1232,8 @@ fn sleep_for_reason(sleep_duration: Duration, reason: &str) {
     );
 }
 
+/// Submit a transaction, and wait for it to show up in the mempool events of the
+/// test observer.
 pub fn submit_tx_and_wait(http_origin: &str, tx: &Vec<u8>) -> String {
     let start = Instant::now();
     let original_tx_count = test_observer::get_memtxs().len();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -6,12 +6,14 @@ use std::time::{Duration, Instant};
 use stacks::burnchains::Burnchain;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::ConsensusHash;
+use stacks::chainstate::stacks::TransactionPayload;
 use stacks::codec::StacksMessageCodec;
 use stacks::net::{AccountEntryResponse, ContractSrcResponse, RPCPeerInfoData};
 use stacks::types::chainstate::{BlockHeaderHash, StacksAddress};
 use stacks::util::get_epoch_time_secs;
-use stacks::util::hash::Hash160;
+use stacks::util::hash::{hex_bytes, Hash160};
 use stacks::vm::types::QualifiedContractIdentifier;
+use stacks::vm::{ClarityName, ContractName};
 use stacks::{
     chainstate::stacks::{
         StacksBlock, StacksBlockHeader, StacksPrivateKey, StacksPublicKey, StacksTransaction,
@@ -20,13 +22,16 @@ use stacks::{
 };
 
 use crate::burnchains::mock_events::{reset_static_burnblock_simulator_channel, MockController};
+use crate::config::{EventKeyType, EventObserverConfig};
 use crate::neon;
 use crate::tests::l1_observer_test::MOCKNET_PRIVATE_KEY_1;
 use crate::tests::{
     make_contract_call, make_contract_publish, make_stacks_transfer, to_addr, SK_1, SK_2, SK_3,
 };
 use crate::{Config, ConfigFile, Keychain};
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
+
+use super::make_contract_call_mblock_only;
 
 pub fn mockstack_test_conf() -> (Config, StacksAddress) {
     let mut conf = super::new_test_conf();
@@ -56,6 +61,8 @@ pub fn mockstack_test_conf() -> (Config, StacksAddress) {
     conf.burnchain.first_burn_header_hash =
         "0000000000000000000000000000000000000000000000000000000000000001".to_string();
     conf.burnchain.first_burn_header_height = 1;
+
+    conf.node.wait_before_first_anchored_block = 5_000;
 
     let miner_account = keychain.origin_address(conf.is_mainnet()).unwrap();
 
@@ -519,7 +526,7 @@ fn mockstack_integration_test() {
     // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);
     btc_regtest_controller.next_block(None);
-    // btc_regtest_controller.next_block(None);
+    btc_regtest_controller.next_block(None);
 
     let (sortition_db, _) = burnchain.open_db(true).unwrap();
 
@@ -553,7 +560,7 @@ fn mockstack_integration_test() {
 
     let account = get_account(&http_origin, &miner_account);
     assert_eq!(account.balance, 0);
-    assert_eq!(account.nonce, 1);
+    assert_eq!(account.nonce, 2);
 
     // query for prometheus metrics
     #[cfg(feature = "monitoring_prom")]
@@ -933,14 +940,7 @@ fn no_contract_calls_forking_integration_test() {
     let (sortition_db, _) = burnchain.open_db(true).unwrap();
 
     btc_regtest_controller.next_block(None);
-
-    next_block_and_wait(
-        &mut btc_regtest_controller,
-        None,
-        &blocks_processed,
-        &sortition_db,
-    );
-    assert_l2_l1_tip_heights(&sortition_db, 0, 2);
+    btc_regtest_controller.next_block(None);
 
     next_block_and_wait(
         &mut btc_regtest_controller,
@@ -950,13 +950,21 @@ fn no_contract_calls_forking_integration_test() {
     );
     assert_l2_l1_tip_heights(&sortition_db, 0, 3);
 
-    let common_ancestor = next_block_and_wait(
+    next_block_and_wait(
         &mut btc_regtest_controller,
         None,
         &blocks_processed,
         &sortition_db,
     );
     assert_l2_l1_tip_heights(&sortition_db, 1, 4);
+
+    let common_ancestor = next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+    assert_l2_l1_tip_heights(&sortition_db, 2, 5);
 
     for i in 0..2 {
         next_block_and_wait(
@@ -965,7 +973,7 @@ fn no_contract_calls_forking_integration_test() {
             &blocks_processed,
             &sortition_db,
         );
-        assert_l2_l1_tip_heights(&sortition_db, 2 + i, 5 + i);
+        assert_l2_l1_tip_heights(&sortition_db, 3 + i, 6 + i);
     }
 
     let mut cursor = common_ancestor;
@@ -979,7 +987,7 @@ fn no_contract_calls_forking_integration_test() {
         &blocks_processed,
         &sortition_db,
     );
-    assert_l2_l1_tip_heights(&sortition_db, 1, 8);
+    assert_l2_l1_tip_heights(&sortition_db, 2, 9);
 
     next_block_and_wait(
         &mut btc_regtest_controller,
@@ -987,7 +995,7 @@ fn no_contract_calls_forking_integration_test() {
         &blocks_processed,
         &sortition_db,
     );
-    assert_l2_l1_tip_heights(&sortition_db, 2, 9);
+    assert_l2_l1_tip_heights(&sortition_db, 3, 10);
 
     termination_switch.store(false, Ordering::SeqCst);
     run_loop_thread.join().expect("Failed to join run loop.");
@@ -999,4 +1007,237 @@ fn assert_l2_l1_tip_heights(sortition_db: &SortitionDB, l2_height: u64, l1_heigh
         .expect("Could not read from SortitionDB.");
     assert_eq!(l2_height, tip_snapshot.canonical_stacks_tip_height);
     assert_eq!(l1_height, tip_snapshot.block_height);
+}
+
+#[test]
+#[ignore]
+fn micro_test() {
+    reset_static_burnblock_simulator_channel();
+    let (mut conf, miner_account) = mockstack_test_conf();
+    conf.node.microblock_frequency = 100;
+    let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
+    let sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
+    let sk_3 = StacksPrivateKey::from_hex(SK_3).unwrap();
+    let addr_2 = to_addr(&sk_2);
+    let addr_3 = to_addr(&sk_3);
+
+    let addr_3_init_balance = 100000;
+    let addr_2_init_balance = 2000;
+
+    conf.add_initial_balance(addr_3.to_string(), addr_3_init_balance);
+    conf.add_initial_balance(addr_2.to_string(), addr_2_init_balance);
+    conf.add_initial_balance(to_addr(&contract_sk).to_string(), 3000);
+
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    info!(
+        "conf.node.wait_before_first_anchored_block: {:?}",
+        &conf.node.wait_before_first_anchored_block
+    );
+    test_observer::spawn();
+
+    let burnchain = Burnchain::new(
+        &conf.get_burn_db_path(),
+        &conf.burnchain.chain,
+        &conf.burnchain.mode,
+    )
+    .unwrap();
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    let mut btc_regtest_controller = MockController::new(conf, channel.clone());
+
+    thread::spawn(move || run_loop.start(None, 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    let (sortition_db, _) = burnchain.open_db(true).unwrap();
+
+    btc_regtest_controller.next_block(None);
+    btc_regtest_controller.next_block(None);
+
+    // first block wakes up the run loop
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+
+    // first block will hold our VRF registration
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+
+    // second block will be the first mined Stacks block
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+
+    let small_contract = "(define-public (return-one) (ok 1))";
+
+    let contract_identifier = QualifiedContractIdentifier::parse(&format!(
+        "{}.{}",
+        to_addr(&contract_sk).to_string(),
+        "faucet"
+    ))
+    .unwrap();
+
+    {
+        let publish_tx =
+            make_contract_publish(&contract_sk, 0, 1000, "small-contract", small_contract);
+        submit_tx_and_wait(&http_origin, &publish_tx);
+    }
+
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+    {
+        let contract_call_tx = make_contract_call(
+            &sk_2,
+            0,
+            1000,
+            &to_addr(&contract_sk),
+            "small-contract",
+            "return-one",
+            &[],
+        );
+        submit_tx_and_wait(&http_origin, &contract_call_tx);
+    }
+
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+
+    {
+        let contract_call_tx = make_contract_call_mblock_only(
+            &sk_2,
+            1,
+            1000,
+            &to_addr(&contract_sk),
+            "small-contract",
+            "return-one",
+            &[],
+        );
+        submit_tx_and_wait(&http_origin, &contract_call_tx);
+    }
+    sleep_for_reason(Duration::from_millis(3000), "wait for micro-blocks");
+
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+
+    {
+        let small_contract_calls = select_transactions_where(
+            &test_observer::get_blocks(),
+            |transaction| match &transaction.payload {
+                TransactionPayload::ContractCall(contract) => {
+                    contract.contract_name == ContractName::try_from("small-contract").unwrap()
+                        && contract.function_name == ClarityName::try_from("return-one").unwrap()
+                }
+                _ => false,
+            },
+        );
+        info!("small_contract_calls: {:?}", &small_contract_calls);
+        assert_eq!(1, small_contract_calls.len());
+    }
+
+    {
+        let small_contract_calls =
+            select_transactions_where(&test_observer::get_microblocks(), |transaction| {
+                match &transaction.payload {
+                    TransactionPayload::ContractCall(contract) => {
+                        contract.contract_name == ContractName::try_from("small-contract").unwrap()
+                            && contract.function_name
+                                == ClarityName::try_from("return-one").unwrap()
+                    }
+                    _ => false,
+                }
+            });
+        info!("small_contract_calls: {:?}", &small_contract_calls);
+        assert_eq!(1, small_contract_calls.len());
+    }
+
+    channel.stop_chains_coordinator();
+}
+
+/// Deserializes the `StacksTransaction` objects from `blocks` and returns all those that
+/// match `test_fn`.
+fn select_transactions_where(
+    blocks: &Vec<serde_json::Value>,
+    test_fn: fn(&StacksTransaction) -> bool,
+) -> Vec<StacksTransaction> {
+    let mut result = vec![];
+    for block in blocks {
+        let transactions = block.get("transactions").unwrap().as_array().unwrap();
+        for tx in transactions.iter() {
+            info!("tx: {:?}", &tx);
+            let raw_tx = tx.get("raw_tx").unwrap().as_str().unwrap();
+            let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
+            let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
+            let test_value = test_fn(&parsed);
+            if test_value {
+                result.push(parsed);
+            }
+        }
+    }
+
+    return result;
+}
+
+fn sleep_for_reason(sleep_duration: Duration, reason: &str) {
+    info!(
+        "sleep_for_reason: START sleep {:?} for reason: {}",
+        serde_json::to_string(&sleep_duration).expect("Serialization failed."),
+        &reason
+    );
+    thread::sleep(sleep_duration);
+    info!(
+        "sleep_for_reason: STOP sleep {:?} for reason: {}",
+        serde_json::to_string(&sleep_duration).expect("Serialization failed."),
+        &reason
+    );
+}
+
+pub fn submit_tx_and_wait(http_origin: &str, tx: &Vec<u8>) -> String {
+    let start = Instant::now();
+    let original_tx_count = test_observer::get_memtxs().len();
+    let result = submit_tx(http_origin, tx);
+    info!("submitted transaction with id: {:?}", &result);
+    while test_observer::get_memtxs().len() <= original_tx_count {
+        if start.elapsed() > Duration::from_secs(PANIC_TIMEOUT_SECS) {
+            panic!("Timed out waiting for run loop to start");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    result
 }


### PR DESCRIPTION
### Description
This change makes it so that the user can specify `wait_before_first_anchored_block`, which specifies a number of milliseconds to wait, after hearing about a burn block, before starting an anchored block.

This allows the system to make micro-blocks in this time.

### Applicable issues
- this is towards requests added to #67
- decreases flakiness in some `l1_observer_test` tests by using `wait_for_next_stacks_block` (#87) 

### Additional info (benefits, drawbacks, caveats)
Benefits:
* this is done to create a window of, e.g., "5 minutes", in which micro-blocks are created, so users can get immediate confirmation of the transactions in that time

Drawbacks:
* if the burn block time is less than e.g. "5 minutes", we will miss that burn block
* transactions are treated differently, depending on whether they go into micro-blocks or the main block

### Alternative
An alternative is to put *all* transactions in micro-blocks. Then, the anchored block fires right after the burn block, with 0 tx's, and only serves to confirm the micro-blocks created in the previous epoch.

Benefits:
* immediate confirmation of transaction times
* can't miss a burn block
* all transactions treated uniformly

### Checklist
- [ ] Test coverage for new or modified code paths
- [ ] New integration test(s) added to `bitcoin-tests.yml`
