### PR TITLE
Feat: Drop first burn hash requirement

### DIFF
--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -349,8 +349,6 @@ impl Burnchain {
         &self,
         indexer: &I,
         readwrite: bool,
-        first_block_header_hash: BurnchainHeaderHash,
-        first_block_header_timestamp: u64,
     ) -> Result<(SortitionDB, BurnchainDB), burnchain_error> {
         Burnchain::setup_chainstate_dirs(&self.working_dir)?;
 
@@ -361,13 +359,8 @@ impl Burnchain {
 
         let sortitiondb =
             SortitionDB::connect(&db_path, self.first_block_height, &epochs, readwrite)?;
-        let burnchaindb = BurnchainDB::connect(
-            &burnchain_db_path,
-            self.first_block_height,
-            &first_block_header_hash,
-            first_block_header_timestamp,
-            readwrite,
-        )?;
+        let burnchaindb =
+            BurnchainDB::connect(&burnchain_db_path, self.first_block_height, readwrite)?;
 
         Ok((sortitiondb, burnchaindb))
     }
@@ -609,12 +602,7 @@ impl Burnchain {
         I: BurnchainIndexer + 'static,
     {
         self.setup_chainstate(indexer)?;
-        let (_, mut burnchain_db) = self.connect_db(
-            indexer,
-            true,
-            indexer.get_first_block_header_hash()?,
-            indexer.get_first_block_header_timestamp()?,
-        )?;
+        let (_, mut burnchain_db) = self.connect_db(indexer, true)?;
 
         let burn_chain_tip = burnchain_db.get_canonical_chain_tip().map_err(|e| {
             error!("Failed to query burn chain tip from burn DB: {}", e);

--- a/src/burnchains/burnchain.rs
+++ b/src/burnchains/burnchain.rs
@@ -359,14 +359,8 @@ impl Burnchain {
         let db_path = self.get_db_path();
         let burnchain_db_path = self.get_burnchaindb_path();
 
-        let sortitiondb = SortitionDB::connect(
-            &db_path,
-            self.first_block_height,
-            &first_block_header_hash,
-            first_block_header_timestamp,
-            &epochs,
-            readwrite,
-        )?;
+        let sortitiondb =
+            SortitionDB::connect(&db_path, self.first_block_height, &epochs, readwrite)?;
         let burnchaindb = BurnchainDB::connect(
             &burnchain_db_path,
             self.first_block_height,

--- a/src/burnchains/db.rs
+++ b/src/burnchains/db.rs
@@ -171,8 +171,6 @@ impl BurnchainDB {
     pub fn connect(
         path: &str,
         first_block_height: u64,
-        first_burn_header_hash: &BurnchainHeaderHash,
-        first_burn_header_timestamp: u64,
         readwrite: bool,
     ) -> Result<BurnchainDB, BurnchainError> {
         let mut create_flag = false;
@@ -214,8 +212,8 @@ impl BurnchainDB {
 
             let first_block_header = BurnchainBlockHeader {
                 block_height: first_block_height,
-                block_hash: first_burn_header_hash.clone(),
-                timestamp: first_burn_header_timestamp,
+                block_hash: BurnchainHeaderHash([0; 32]),
+                timestamp: 0,
                 num_txs: 0,
                 parent_block_hash: BurnchainHeaderHash::sentinel(),
             };

--- a/src/burnchains/test.rs
+++ b/src/burnchains/test.rs
@@ -622,7 +622,7 @@ impl TestBurnchainNode {
     pub fn new() -> TestBurnchainNode {
         let first_block_height = 100;
         let first_block_hash = BurnchainHeaderHash([0u8; 32]);
-        let db = SortitionDB::connect_test(first_block_height, &first_block_hash).unwrap();
+        let db = SortitionDB::connect_test(first_block_height).unwrap();
         TestBurnchainNode {
             sortdb: db,
             dirty: false,

--- a/src/chainstate/burn/db/processing.rs
+++ b/src/chainstate/burn/db/processing.rs
@@ -339,10 +339,17 @@ impl<'a> SortitionHandleTx<'a> {
             parent_snapshot.block_height + 1,
             this_block_header.block_height
         );
-        assert_eq!(
-            parent_snapshot.burn_header_hash,
-            this_block_header.parent_block_hash
-        );
+        if parent_snapshot.block_height == self.context.first_block_height {
+            assert_eq!(
+                parent_snapshot.burn_header_hash,
+                BurnchainHeaderHash([0; 32])
+            );
+        } else {
+            assert_eq!(
+                parent_snapshot.burn_header_hash,
+                this_block_header.parent_block_hash
+            );
+        }
 
         let new_snapshot = self.process_block_ops(
             burnchain,
@@ -391,7 +398,7 @@ mod tests {
 
         let mut burnchain = Burnchain::default_unittest(100, &first_burn_hash);
         burnchain.initial_reward_start_block = 90;
-        let mut db = SortitionDB::connect_test(100, &first_burn_hash).unwrap();
+        let mut db = SortitionDB::connect_test(100).unwrap();
 
         let snapshot = test_append_snapshot(&mut db, BurnchainHeaderHash([0x01; 32]), &vec![]);
 

--- a/src/chainstate/burn/db/tests.rs
+++ b/src/chainstate/burn/db/tests.rs
@@ -187,7 +187,7 @@ fn test_insert_block_commit() {
 fn is_fresh_consensus_hash() {
     let consensus_hash_lifetime = 24;
     let first_burn_hash = BurnchainHeaderHash::from_hex(
-        "10000000000000000000000000000000000000000000000000000000000000ff",
+        "0000000000000000000000000000000000000000000000000000000000000000",
     )
     .unwrap();
     let mut db = SortitionDB::connect_test(0).unwrap();
@@ -195,14 +195,14 @@ fn is_fresh_consensus_hash() {
         let mut last_snapshot = SortitionDB::get_first_block_snapshot(db.conn()).unwrap();
         for i in 0..255 {
             let sortition_id = SortitionId([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, i as u8,
             ]);
             let parent_sortition_id = if i == 0 {
                 last_snapshot.sortition_id.clone()
             } else {
                 SortitionId([
-                    0,
+                    1,
                     0,
                     0,
                     0,
@@ -244,14 +244,14 @@ fn is_fresh_consensus_hash() {
                 block_height: i as u64 + 1,
                 burn_header_timestamp: get_epoch_time_secs(),
                 burn_header_hash: BurnchainHeaderHash::from_bytes(&[
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, i as u8,
                 ])
                 .unwrap(),
                 sortition_id,
                 parent_sortition_id,
                 parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
-                    (if i == 0 { 0x10 } else { 0 }) as u8,
+                    (if i == 0 { 0x00 } else { 1 }) as u8,
                     0,
                     0,
                     0,
@@ -282,11 +282,11 @@ fn is_fresh_consensus_hash() {
                     0,
                     0,
                     0,
-                    (if i == 0 { 0xff } else { i - 1 }) as u8,
+                    (if i == 0 { 0 } else { i - 1 }) as u8,
                 ])
                 .unwrap(),
                 consensus_hash: ConsensusHash::from_bytes(&[
-                    0,
+                    1,
                     0,
                     0,
                     0,
@@ -309,7 +309,7 @@ fn is_fresh_consensus_hash() {
                 ])
                 .unwrap(),
                 ops_hash: OpsHash::from_bytes(&[
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, i as u8,
                 ])
                 .unwrap(),
@@ -345,10 +345,10 @@ fn is_fresh_consensus_hash() {
     let tip = SortitionDB::get_canonical_burn_chain_tip(db.conn()).unwrap();
 
     let ch_fresh =
-        ConsensusHash::from_bytes(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255])
+        ConsensusHash::from_bytes(&[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255])
             .unwrap();
     let ch_oldest_fresh = ConsensusHash::from_bytes(&[
-        0,
+        1,
         0,
         0,
         0,
@@ -371,7 +371,7 @@ fn is_fresh_consensus_hash() {
     ])
     .unwrap();
     let ch_newest_stale = ConsensusHash::from_bytes(&[
-        0,
+        1,
         0,
         0,
         0,
@@ -394,7 +394,7 @@ fn is_fresh_consensus_hash() {
     ])
     .unwrap();
     let ch_missing =
-        ConsensusHash::from_bytes(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 255])
+        ConsensusHash::from_bytes(&[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 255])
             .unwrap();
 
     let mut ic = SortitionHandleTx::begin(&mut db, &tip.sortition_id).unwrap();
@@ -425,23 +425,19 @@ fn is_fresh_consensus_hash() {
 
 #[test]
 fn get_consensus_at() {
-    let first_burn_hash = BurnchainHeaderHash::from_hex(
-        "10000000000000000000000000000000000000000000000000000000000000ff",
-    )
-    .unwrap();
     let mut db = SortitionDB::connect_test(0).unwrap();
     {
         let mut last_snapshot = SortitionDB::get_first_block_snapshot(db.conn()).unwrap();
         for i in 0..256u64 {
             let sortition_id = SortitionId([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, i as u8,
             ]);
             let parent_sortition_id = if i == 0 {
                 last_snapshot.sortition_id.clone()
             } else {
                 SortitionId([
-                    0,
+                    1,
                     0,
                     0,
                     0,
@@ -483,14 +479,14 @@ fn get_consensus_at() {
                 block_height: i as u64 + 1,
                 burn_header_timestamp: get_epoch_time_secs(),
                 burn_header_hash: BurnchainHeaderHash::from_bytes(&[
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, i as u8,
                 ])
                 .unwrap(),
                 sortition_id,
                 parent_sortition_id,
                 parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
-                    (if i == 0 { 0x10 } else { 0 }) as u8,
+                    (if i == 0 { 0 } else { 1 }) as u8,
                     0,
                     0,
                     0,
@@ -521,11 +517,11 @@ fn get_consensus_at() {
                     0,
                     0,
                     0,
-                    (if i == 0 { 0xff } else { i - 1 }) as u8,
+                    (if i == 0 { 0 } else { i - 1 }) as u8,
                 ])
                 .unwrap(),
                 consensus_hash: ConsensusHash::from_bytes(&[
-                    0,
+                    1,
                     0,
                     0,
                     0,
@@ -548,7 +544,7 @@ fn get_consensus_at() {
                 ])
                 .unwrap(),
                 ops_hash: OpsHash::from_bytes(&[
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, i as u8,
                 ])
                 .unwrap(),
@@ -587,11 +583,13 @@ fn get_consensus_at() {
 
     let tip = SortitionDB::get_canonical_burn_chain_tip(db.conn()).unwrap();
 
-    for i in 0..256 {
+    // start lookups from height = 1, start height is 0, so it will always
+    //  return the "initial" burn block
+    for i in 1..256 {
         // should succeed within the conn
         let ic = db.index_handle(&tip.sortition_id);
         let expected_ch = ConsensusHash::from_bytes(&[
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, i as u8,
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, i as u8,
         ])
         .unwrap();
         let ch = ic.get_consensus_at(i).unwrap().unwrap();
@@ -605,7 +603,7 @@ fn get_last_snapshot_with_sortition() {
     let total_burn_sortition = 100;
     let total_burn_no_sortition = 200;
     let first_burn_hash = BurnchainHeaderHash::from_hex(
-        "0000000000000000000000000000000000000000000000000000000000000000",
+        "1000000000000000000000000000000000000000000000000000000000000000",
     )
     .unwrap();
 
@@ -616,9 +614,9 @@ fn get_last_snapshot_with_sortition() {
         burn_header_timestamp: get_epoch_time_secs(),
         burn_header_hash: first_burn_hash.clone(),
         sortition_id: SortitionId(first_burn_hash.0.clone()),
-        parent_sortition_id: SortitionId(first_burn_hash.0.clone()),
+        parent_sortition_id: SortitionId([0; 32]),
         parent_burn_header_hash: BurnchainHeaderHash([0xff; 32]),
-        consensus_hash: ConsensusHash::from_hex("0000000000000000000000000000000000000000")
+        consensus_hash: ConsensusHash::from_hex("1000000000000000000000000000000000000000")
             .unwrap(),
         ops_hash: OpsHash::from_hex(
             "0000000000000000000000000000000000000000000000000000000000000000",
@@ -636,7 +634,7 @@ fn get_last_snapshot_with_sortition() {
         )
         .unwrap(),
         index_root: TrieHash([0u8; 32]),
-        num_sortitions: 0,
+        num_sortitions: 1,
         stacks_block_accepted: false,
         stacks_block_height: 0,
         arrival_index: 0,
@@ -689,7 +687,7 @@ fn get_last_snapshot_with_sortition() {
         )
         .unwrap(),
         index_root: TrieHash([1u8; 32]),
-        num_sortitions: 1,
+        num_sortitions: 2,
         stacks_block_accepted: false,
         stacks_block_height: 0,
         arrival_index: 0,
@@ -712,15 +710,8 @@ fn get_last_snapshot_with_sortition() {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 1,
         ]),
-        parent_sortition_id: SortitionId([
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0,
-        ]),
-        parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0,
-        ])
-        .unwrap(),
+        parent_sortition_id: SortitionId(first_burn_hash.0.clone()),
+        parent_burn_header_hash: first_burn_hash.clone(),
         consensus_hash: ConsensusHash::from_bytes(&[
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
         ])
@@ -742,7 +733,7 @@ fn get_last_snapshot_with_sortition() {
         )
         .unwrap(),
         index_root: TrieHash([2u8; 32]),
-        num_sortitions: 0,
+        num_sortitions: 1,
         stacks_block_accepted: false,
         stacks_block_height: 0,
         arrival_index: 0,
@@ -751,10 +742,18 @@ fn get_last_snapshot_with_sortition() {
         canonical_stacks_tip_consensus_hash: ConsensusHash([0u8; 20]),
     };
 
-    let mut db = SortitionDB::connect_test(block_height - 2).unwrap();
+    let mut db = SortitionDB::connect_test(block_height - 3).unwrap();
+
+    {
+        let chain_tip = SortitionDB::get_canonical_burn_chain_tip(db.conn()).unwrap();
+        let mut tx = SortitionHandleTx::begin(&mut db, &chain_tip.sortition_id).unwrap();
+
+        tx.append_chain_tip_snapshot(&chain_tip, &first_snapshot, &vec![], None, None)
+            .unwrap();
+        tx.commit().unwrap();
+    }
 
     let chain_tip = SortitionDB::get_canonical_burn_chain_tip(db.conn()).unwrap();
-
     let initial_snapshot = {
         let ic = db.index_handle(&chain_tip.sortition_id);
         ic.get_last_snapshot_with_sortition(block_height - 2)
@@ -1249,10 +1248,6 @@ fn test_chain_reorg() {
 
 #[test]
 fn test_get_stacks_header_hashes() {
-    let first_burn_hash = BurnchainHeaderHash::from_hex(
-        "10000000000000000000000000000000000000000000000000000000000000ff",
-    )
-    .unwrap();
     let mut db = SortitionDB::connect_test(0).unwrap();
     {
         let mut last_snapshot = SortitionDB::get_first_block_snapshot(db.conn()).unwrap();
@@ -1266,56 +1261,59 @@ fn test_get_stacks_header_hashes() {
                     block_height: i + 1,
                     burn_header_timestamp: get_epoch_time_secs(),
                     burn_header_hash: BurnchainHeaderHash::from_bytes(&[
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, i as u8,
                     ])
                     .unwrap(),
                     sortition_id: SortitionId([
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, i as u8,
                     ]),
                     parent_sortition_id: last_snapshot.sortition_id.clone(),
-                    parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
-                        (if i == 0 { 0x10 } else { 0 }) as u8,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        (if i == 0 { 0xff } else { i - 1 }) as u8,
-                    ])
-                    .unwrap(),
+                    parent_burn_header_hash: if i == 0 {
+                        BurnchainHeaderHash([0; 32])
+                    } else {
+                        BurnchainHeaderHash([
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            (i - 1) as u8,
+                        ])
+                    },
                     consensus_hash: ConsensusHash::from_bytes(&[
                         1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, i as u8,
                     ])
                     .unwrap(),
                     ops_hash: OpsHash::from_bytes(&[
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, i as u8,
                     ])
                     .unwrap(),
@@ -1342,56 +1340,59 @@ fn test_get_stacks_header_hashes() {
                     block_height: i + 1,
                     burn_header_timestamp: get_epoch_time_secs(),
                     burn_header_hash: BurnchainHeaderHash::from_bytes(&[
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, i as u8,
                     ])
                     .unwrap(),
                     sortition_id: SortitionId([
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, i as u8,
                     ]),
                     parent_sortition_id: last_snapshot.sortition_id.clone(),
-                    parent_burn_header_hash: BurnchainHeaderHash::from_bytes(&[
-                        (if i == 0 { 0x10 } else { 0 }) as u8,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        (if i == 0 { 0xff } else { i - 1 }) as u8,
-                    ])
-                    .unwrap(),
+                    parent_burn_header_hash: if i == 0 {
+                        BurnchainHeaderHash([0; 32])
+                    } else {
+                        BurnchainHeaderHash([
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            (i - 1) as u8,
+                        ])
+                    },
                     consensus_hash: ConsensusHash::from_bytes(&[
                         1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, i as u8,
                     ])
                     .unwrap(),
                     ops_hash: OpsHash::from_bytes(&[
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, i as u8,
                     ])
                     .unwrap(),
@@ -1627,6 +1628,11 @@ fn make_fork_run(
 ) -> () {
     let mut last_snapshot = start_snapshot.clone();
     for i in last_snapshot.block_height..(last_snapshot.block_height + length) {
+        info!(
+            "Producing block height {}, with consensus_hash = {:x}",
+            i,
+            (i + 1) as u8 | bit_pattern
+        );
         let snapshot = BlockSnapshot {
             accumulated_coinbase_ustx: 0,
             pox_valid: true,
@@ -1667,28 +1673,28 @@ fn make_fork_run(
 
 #[test]
 fn test_set_stacks_block_accepted() {
-    let first_burn_hash = BurnchainHeaderHash::from_hex(
-        "10000000000000000000000000000000000000000000000000000000000000ff",
-    )
-    .unwrap();
     let mut db = SortitionDB::connect_test(0).unwrap();
 
     let mut last_snapshot = SortitionDB::get_first_block_snapshot(db.conn()).unwrap();
 
     // seed a single fork
-    make_fork_run(&mut db, &last_snapshot, 5, 0);
+    make_fork_run(&mut db, &last_snapshot, 5, 0x60);
 
     // set some blocks as processed
     for i in 0..5 {
-        let consensus_hash = ConsensusHash([(i + 1) as u8; 20]);
-        let parent_stacks_block_hash = if i == 0 {
+        let consensus_hash = ConsensusHash([(i + 1) | 0x60; 20]);
+        let parent_stacks_block_hash = if i <= 1 {
             FIRST_STACKS_BLOCK_HASH.clone()
         } else {
-            BlockHeaderHash([(i - 1) as u8; 32])
+            BlockHeaderHash([(i - 1) | 0x60 as u8; 32])
         };
 
-        let stacks_block_hash = BlockHeaderHash([i as u8; 32]);
-        let height = i;
+        let stacks_block_hash = if i == 0 {
+            FIRST_STACKS_BLOCK_HASH.clone()
+        } else {
+            BlockHeaderHash([i | 0x60 as u8; 32])
+        };
+        let height = i as u64;
 
         {
             let mut tx = db.tx_begin_at_tip();
@@ -1703,30 +1709,35 @@ fn test_set_stacks_block_accepted() {
         }
 
         // chain tip is memoized to the current burn chain tip
+        info!("Storing {} at {}", &stacks_block_hash, &consensus_hash);
         let (block_consensus_hash, block_bhh) =
             SortitionDB::get_canonical_stacks_chain_tip_hash(db.conn()).unwrap();
+        info!("Stored {} at {}", &block_bhh, &block_consensus_hash);
         assert_eq!(block_consensus_hash, consensus_hash);
         assert_eq!(block_bhh, stacks_block_hash);
     }
 
     // materialize all block arrivals in the MARF
-    last_snapshot = SortitionDB::get_block_snapshot(db.conn(), &SortitionId([0x04; 32]))
+    last_snapshot = SortitionDB::get_block_snapshot(db.conn(), &SortitionId([0x64; 32]))
         .unwrap()
         .unwrap();
-    make_fork_run(&mut db, &last_snapshot, 1, 0);
+    make_fork_run(&mut db, &last_snapshot, 1, 0x60);
 
     // verify that all Stacks block in this fork can be looked up from this chain tip
     last_snapshot = SortitionDB::get_canonical_burn_chain_tip(db.conn()).unwrap();
     {
         let ic = db.index_conn();
-        for i in 0..5 {
-            let parent_stacks_block_hash = BlockHeaderHash([i as u8; 32]);
+        for i in 1..5 {
+            let parent_stacks_block_hash = if i == 0 {
+                FIRST_STACKS_BLOCK_HASH.clone()
+            } else {
+                BlockHeaderHash([i | 0x60; 32])
+            };
             let parent_key = db_keys::stacks_block_index(&parent_stacks_block_hash);
 
-            test_debug!(
+            info!(
                 "Look up '{}' off of {}",
-                &parent_key,
-                &last_snapshot.burn_header_hash
+                &parent_key, &last_snapshot.burn_header_hash
             );
             let value_opt = ic
                 .get_indexed(&last_snapshot.sortition_id, &parent_key)
@@ -1749,17 +1760,17 @@ fn test_set_stacks_block_accepted() {
     assert_eq!(last_snapshot.canonical_stacks_tip_height, 4);
     assert_eq!(
         last_snapshot.canonical_stacks_tip_hash,
-        BlockHeaderHash([0x04; 32])
+        BlockHeaderHash([0x64; 32])
     );
     assert_eq!(
         last_snapshot.canonical_stacks_tip_consensus_hash,
-        ConsensusHash([0x05; 20])
+        ConsensusHash([0x65; 20])
     );
 
     // accept blocks 5 and 7 in one fork, and 6, 8, 9 in another.
     // Stacks fork 1,2,3,4,5,7 will be the longest fork.
     // Stacks fork 1,2,3,4 will overtake it when blocks 6,8,9 are processed.
-    let mut parent_stacks_block_hash = BlockHeaderHash([0x04; 32]);
+    let mut parent_stacks_block_hash = BlockHeaderHash([0x64; 32]);
     for (i, height) in [5, 7].iter().zip([5, 6].iter()) {
         let consensus_hash = ConsensusHash([((i + 1) | 0x80) as u8; 20]);
         let stacks_block_hash = BlockHeaderHash([(i | 0x80) as u8; 32]);
@@ -1805,7 +1816,7 @@ fn test_set_stacks_block_accepted() {
     // block 7.  The two stacks forks will be:
     // * 1,2,3,4,5,7
     // * 1,2,3,4,6,8
-    parent_stacks_block_hash = BlockHeaderHash([4u8; 32]);
+    parent_stacks_block_hash = BlockHeaderHash([0x64; 32]);
     for (i, height) in [6, 8].iter().zip([5, 6].iter()) {
         let consensus_hash = ConsensusHash([((i + 1) | 0x80) as u8; 20]);
         let stacks_block_hash = BlockHeaderHash([(i | 0x80) as u8; 32]);
@@ -1853,10 +1864,17 @@ fn test_set_stacks_block_accepted() {
         }
 
         // we've overtaken the longest fork with a different longest fork on this burn chain fork
+        info!(
+            "Canonical snapshot: {} < {}",
+            SortitionDB::get_canonical_burn_chain_tip(db.conn())
+                .unwrap()
+                .canonical_stacks_tip_height,
+            height
+        );
         let (block_consensus_hash, block_bhh) =
             SortitionDB::get_canonical_stacks_chain_tip_hash(db.conn()).unwrap();
-        assert_eq!(block_consensus_hash, consensus_hash);
         assert_eq!(block_bhh, stacks_block_hash);
+        assert_eq!(block_consensus_hash, consensus_hash);
     }
 
     // canonical stacks chain tip is now stacks block 9
@@ -1883,20 +1901,20 @@ fn test_set_stacks_block_accepted() {
     //
     // stx:      1,    2,    3,    4
     // burn:  0x01, 0x02, 0x03, 0x04, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b
-    last_snapshot = SortitionDB::get_block_snapshot(db.conn(), &SortitionId([0x04; 32]))
+    last_snapshot = SortitionDB::get_block_snapshot(db.conn(), &SortitionId([0x64; 32]))
         .unwrap()
         .unwrap();
     assert_eq!(
         last_snapshot.burn_header_hash,
-        BurnchainHeaderHash([0x04; 32])
+        BurnchainHeaderHash([0x64; 32])
     );
     assert_eq!(
         last_snapshot.canonical_stacks_tip_consensus_hash,
-        ConsensusHash([0x05; 20])
+        ConsensusHash([0x65; 20])
     );
     assert_eq!(
         last_snapshot.canonical_stacks_tip_hash,
-        BlockHeaderHash([0x04; 32])
+        BlockHeaderHash([0x64; 32])
     );
 
     make_fork_run(&mut db, &last_snapshot, 7, 0x40);
@@ -1910,11 +1928,11 @@ fn test_set_stacks_block_accepted() {
     );
     assert_eq!(
         last_snapshot.canonical_stacks_tip_consensus_hash,
-        ConsensusHash([0x05; 20])
+        ConsensusHash([0x65; 20])
     );
     assert_eq!(
         last_snapshot.canonical_stacks_tip_hash,
-        BlockHeaderHash([0x04; 32])
+        BlockHeaderHash([0x64; 32])
     );
     assert_eq!(last_snapshot.canonical_stacks_tip_height, 4);
 
@@ -1923,7 +1941,7 @@ fn test_set_stacks_block_accepted() {
         let mut tx = db.tx_begin_at_tip();
         tx.set_stacks_block_accepted(
             &ConsensusHash([0x4c; 20]),
-            &BlockHeaderHash([0x04; 32]),
+            &BlockHeaderHash([0x64; 32]),
             &BlockHeaderHash([0x4b; 32]),
             5,
         )
@@ -1971,11 +1989,11 @@ fn test_set_stacks_block_accepted() {
     );
     assert_eq!(
         last_snapshot.canonical_stacks_tip_consensus_hash,
-        ConsensusHash([0x05; 20])
+        ConsensusHash([0x65; 20])
     );
     assert_eq!(
         last_snapshot.canonical_stacks_tip_hash,
-        BlockHeaderHash([0x04; 32])
+        BlockHeaderHash([0x64; 32])
     );
     assert_eq!(last_snapshot.canonical_stacks_tip_height, 4);
 
@@ -2000,7 +2018,7 @@ fn test_set_stacks_block_accepted() {
         let mut tx = db.tx_handle_begin(&SortitionId([0x2a; 32])).unwrap();
         tx.set_stacks_block_accepted(
             &ConsensusHash([0x2a; 20]),
-            &BlockHeaderHash([0x04; 32]),
+            &BlockHeaderHash([0x64; 32]),
             &BlockHeaderHash([0x29; 32]),
             5,
         )
@@ -2067,7 +2085,7 @@ fn test_set_stacks_block_accepted() {
         let mut tx = db.tx_begin_at_tip();
         tx.set_stacks_block_accepted(
             &ConsensusHash([0x46; 20]),
-            &BlockHeaderHash([0x04; 32]),
+            &BlockHeaderHash([0x64; 32]),
             &BlockHeaderHash([0x45; 32]),
             5,
         )

--- a/src/chainstate/burn/mod.rs
+++ b/src/chainstate/burn/mod.rs
@@ -393,7 +393,7 @@ mod tests {
             "0000000000000000000000000000000000000000000000000000000000000000",
         )
         .unwrap();
-        let mut db = SortitionDB::connect_test(0, &first_burn_hash).unwrap();
+        let mut db = SortitionDB::connect_test(0).unwrap();
         let mut burn_block_hashes = vec![];
         {
             let mut prev_snapshot = SortitionDB::get_first_block_snapshot(db.conn()).unwrap();

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -51,7 +51,7 @@ impl BlockSnapshot {
     pub fn initial(first_block_height: u64) -> BlockSnapshot {
         BlockSnapshot {
             block_height: first_block_height,
-            burn_header_hash: BurnchainHeaderHash::sentinel(),
+            burn_header_hash: BurnchainHeaderHash([0; 32]),
             burn_header_timestamp: 0,
             parent_burn_header_hash: BurnchainHeaderHash::sentinel(),
             consensus_hash: ConsensusHash([0u8; 20]),
@@ -69,7 +69,7 @@ impl BlockSnapshot {
             canonical_stacks_tip_height: 0,
             canonical_stacks_tip_hash: FIRST_STACKS_BLOCK_HASH.clone(),
             canonical_stacks_tip_consensus_hash: FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
-            sortition_id: SortitionId::sentinel(),
+            sortition_id: SortitionId([0; 32]),
             parent_sortition_id: SortitionId::sentinel(),
             pox_valid: true,
             accumulated_coinbase_ustx: 0,
@@ -165,10 +165,17 @@ impl BlockSnapshot {
         _block_burn_total: Option<u64>,
         initial_mining_bonus_ustx: u128,
     ) -> Result<BlockSnapshot, db_error> {
-        assert_eq!(
-            parent_snapshot.burn_header_hash,
-            block_header.parent_block_hash
-        );
+        if parent_snapshot.block_height == burnchain.first_block_height {
+            assert_eq!(
+                parent_snapshot.burn_header_hash,
+                BurnchainHeaderHash([0; 32])
+            );
+        } else {
+            assert_eq!(
+                parent_snapshot.burn_header_hash,
+                block_header.parent_block_hash
+            );
+        }
         assert_eq!(parent_snapshot.block_height + 1, block_header.block_height);
 
         let block_height = block_header.block_height;

--- a/src/chainstate/burn/sortition.rs
+++ b/src/chainstate/burn/sortition.rs
@@ -48,15 +48,11 @@ use stacks_common::types::chainstate::TrieHash;
 
 impl BlockSnapshot {
     /// Create the sentinel block snapshot -- the first one
-    pub fn initial(
-        first_block_height: u64,
-        first_burn_header_hash: &BurnchainHeaderHash,
-        first_burn_header_timestamp: u64,
-    ) -> BlockSnapshot {
+    pub fn initial(first_block_height: u64) -> BlockSnapshot {
         BlockSnapshot {
             block_height: first_block_height,
-            burn_header_hash: first_burn_header_hash.clone(),
-            burn_header_timestamp: first_burn_header_timestamp,
+            burn_header_hash: BurnchainHeaderHash::sentinel(),
+            burn_header_timestamp: 0,
             parent_burn_header_hash: BurnchainHeaderHash::sentinel(),
             consensus_hash: ConsensusHash([0u8; 20]),
             ops_hash: OpsHash([0u8; 32]),
@@ -73,8 +69,8 @@ impl BlockSnapshot {
             canonical_stacks_tip_height: 0,
             canonical_stacks_tip_hash: FIRST_STACKS_BLOCK_HASH.clone(),
             canonical_stacks_tip_consensus_hash: FIRST_BURNCHAIN_CONSENSUS_HASH.clone(),
-            sortition_id: SortitionId::new(first_burn_header_hash),
-            parent_sortition_id: SortitionId::new(first_burn_header_hash),
+            sortition_id: SortitionId::sentinel(),
+            parent_sortition_id: SortitionId::sentinel(),
             pox_valid: true,
             accumulated_coinbase_ustx: 0,
         }

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -186,8 +186,6 @@ pub fn setup_states(
         let burnchain_blocks_db = BurnchainDB::connect(
             &burnchain.get_burnchaindb_path(),
             burnchain.first_block_height,
-            &burnchain.first_block_hash,
-            burnchain.first_block_timestamp as u64,
             true,
         )
         .unwrap();

--- a/src/chainstate/coordinator/tests.rs
+++ b/src/chainstate/coordinator/tests.rs
@@ -178,8 +178,6 @@ pub fn setup_states(
         let sortition_db = SortitionDB::connect(
             &burnchain.get_db_path(),
             burnchain.first_block_height,
-            &burnchain.first_block_hash,
-            burnchain.first_block_timestamp.into(),
             &epochs,
             true,
         )
@@ -835,79 +833,4 @@ fn preprocess_block(
             5,
         )
         .unwrap();
-}
-
-#[test]
-fn test_check_chainstate_db_versions() {
-    let path = "/tmp/stacks-blockchain-check_chainstate_db_versions";
-    let _ = std::fs::remove_dir_all(path);
-
-    let sortdb_path = format!("{}/sortdb", &path);
-    let chainstate_path = format!("{}/chainstate", &path);
-
-    let epoch_2 = StacksEpoch {
-        epoch_id: StacksEpochId::Epoch20,
-        start_height: 0,
-        end_height: 10000,
-        block_limit: BLOCK_LIMIT_MAINNET_20.clone(),
-        network_epoch: PEER_VERSION_EPOCH_2_0,
-    };
-    let epoch_2_05 = StacksEpoch {
-        epoch_id: StacksEpochId::Epoch2_05,
-        start_height: 0,
-        end_height: 10000,
-        block_limit: BLOCK_LIMIT_MAINNET_205.clone(),
-        network_epoch: PEER_VERSION_EPOCH_2_05,
-    };
-
-    // should work just fine in epoch 2 if the DBs don't exist
-    assert!(
-        check_chainstate_db_versions(&[epoch_2.clone()], &sortdb_path, &chainstate_path).unwrap()
-    );
-
-    // should work just fine in epoch 2.05 if the DBs don't exist
-    assert!(
-        check_chainstate_db_versions(&[epoch_2_05.clone()], &sortdb_path, &chainstate_path)
-            .unwrap()
-    );
-
-    StacksChainState::make_chainstate_dirs(&chainstate_path).unwrap();
-
-    let sortdb_v1 =
-        SortitionDB::connect_v1(&sortdb_path, 100, &BurnchainHeaderHash([0x00; 32]), 0, true)
-            .unwrap();
-    let chainstate_v1 = StacksChainState::open_db_without_migrations(
-        false,
-        CHAIN_ID_TESTNET,
-        &StacksChainState::header_index_root_path(PathBuf::from(&chainstate_path))
-            .to_str()
-            .unwrap(),
-    )
-    .unwrap();
-
-    assert!(fs::metadata(&chainstate_path).is_ok());
-    assert!(fs::metadata(&sortdb_path).is_ok());
-    assert_eq!(
-        StacksChainState::get_db_config_from_path(&chainstate_path)
-            .unwrap()
-            .version,
-        "1"
-    );
-    assert_eq!(
-        SortitionDB::get_db_version_from_path(&sortdb_path)
-            .unwrap()
-            .unwrap(),
-        "1"
-    );
-
-    // should work just fine in epoch 2
-    assert!(
-        check_chainstate_db_versions(&[epoch_2.clone()], &sortdb_path, &chainstate_path).unwrap()
-    );
-
-    // should fail in epoch 2.05
-    assert!(
-        !check_chainstate_db_versions(&[epoch_2_05.clone()], &sortdb_path, &chainstate_path)
-            .unwrap()
-    );
 }

--- a/src/chainstate/stacks/block.rs
+++ b/src/chainstate/stacks/block.rs
@@ -1291,9 +1291,9 @@ mod test {
             miner_signatures: MessageSignatureList::empty(),
         };
 
-        let mut burn_chain_tip = BlockSnapshot::initial(122, &BurnchainHeaderHash([3u8; 32]), 0);
-        let mut stacks_chain_tip = BlockSnapshot::initial(122, &BurnchainHeaderHash([3u8; 32]), 1);
-        let sortition_chain_tip = BlockSnapshot::initial(122, &BurnchainHeaderHash([3u8; 32]), 2);
+        let mut burn_chain_tip = BlockSnapshot::initial(122);
+        let mut stacks_chain_tip = BlockSnapshot::initial(122);
+        let sortition_chain_tip = BlockSnapshot::initial(122);
 
         let block_commit = LeaderBlockCommitOp {
             block_header_hash: header.block_hash(),

--- a/src/chainstate/stacks/db/blocks.rs
+++ b/src/chainstate/stacks/db/blocks.rs
@@ -4613,7 +4613,7 @@ impl StacksChainState {
     /// hyperchains fork yet.
     pub fn process_deposit_stx_ops(
         clarity_tx: &mut ClarityTx,
-        mut operations: Vec<DepositStxOp>,
+        operations: Vec<DepositStxOp>,
     ) -> Vec<StacksTransactionReceipt> {
         let cost_so_far = clarity_tx.cost_so_far();
         let (all_receipts, _) =
@@ -4623,7 +4623,7 @@ impl StacksChainState {
                     .filter_map(|deposit_stx_op| {
                         let DepositStxOp {
                             txid,
-                            burn_header_hash,
+                            burn_header_hash: _,
                             amount,
                             sender,
                             ..
@@ -4677,7 +4677,7 @@ impl StacksChainState {
                     burn_header_hash,
                     hc_contract_id,
                     hc_function_name,
-                    name,
+                    name: _,
                     amount,
                     sender,
                     ..

--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -1950,7 +1950,7 @@ impl StacksBlockBuilder {
             parent_stacks_header.stacks_block_height,
         );
 
-        debug!(
+        info!(
             "Build anchored block off of {}/{} height {}",
             &tip_consensus_hash, &tip_block_hash, tip_height
         );
@@ -1969,8 +1969,10 @@ impl StacksBlockBuilder {
         let ts_start = get_epoch_time_ms();
 
         let mut miner_epoch_info = builder.pre_epoch_begin(&mut chainstate, burn_dbconn)?;
+
         let (mut epoch_tx, confirmed_mblock_cost) =
             builder.epoch_begin(burn_dbconn, &mut miner_epoch_info)?;
+
         let stacks_epoch_id = epoch_tx.get_epoch();
         let block_limit = epoch_tx
             .block_limit()
@@ -1997,7 +1999,7 @@ impl StacksBlockBuilder {
         let deadline = ts_start + (max_miner_time_ms as u128);
         let mut num_txs = 0;
 
-        debug!(
+        info!(
             "Anchored block transaction selection begins (child of {})",
             &parent_stacks_header.anchored_header.block_hash()
         );
@@ -2127,7 +2129,7 @@ impl StacksBlockBuilder {
                     break;
                 }
             }
-            debug!("Anchored block transaction selection finished (child of {}): {} transactions selected ({} considered)", &parent_stacks_header.anchored_header.block_hash(), num_txs, considered.len());
+            info!("Anchored block transaction selection finished (child of {}): {} transactions selected ({} considered)", &parent_stacks_header.anchored_header.block_hash(), num_txs, considered.len());
             intermediate_result
         };
 
@@ -2167,7 +2169,7 @@ impl StacksBlockBuilder {
             );
         }
 
-        debug!(
+        info!(
             "Miner: mined anchored block";
             "block_hash" => %block.block_hash(),
             "height" => block.header.total_work.work,

--- a/src/clarity_vm/tests/epoch_switch.rs
+++ b/src/clarity_vm/tests/epoch_switch.rs
@@ -79,8 +79,6 @@ fn test_vm_epoch_switch() {
     let mut db = SortitionDB::connect(
         &db_path_dir,
         3,
-        &BurnchainHeaderHash([0u8; 32]),
-        0,
         &vec![
             StacksEpoch {
                 epoch_id: StacksEpochId::Epoch10,

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -4030,7 +4030,7 @@ mod test {
         )
         .unwrap();
 
-        let mut sortdb_1 = SortitionDB::connect_test(12300, &first_burn_hash).unwrap();
+        let mut sortdb_1 = SortitionDB::connect_test(12300).unwrap();
 
         db_setup(&mut peerdb_1, &mut sortdb_1, &socketaddr_1, &chain_view);
 

--- a/src/net/chat.rs
+++ b/src/net/chat.rs
@@ -2336,8 +2336,6 @@ mod test {
         let sortdb = SortitionDB::connect(
             &sortdb_path,
             burnchain.first_block_height,
-            &burnchain.first_block_hash,
-            get_epoch_time_secs(),
             &StacksEpoch::unit_test_pre_2_05(burnchain.first_block_height),
             true,
         )

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2652,8 +2652,6 @@ pub mod test {
             let _burnchain_blocks_db = BurnchainDB::connect(
                 &config.burnchain.get_burnchaindb_path(),
                 first_burnchain_block_height,
-                &first_burnchain_block_hash,
-                0,
                 true,
             )
             .unwrap();

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2641,8 +2641,6 @@ pub mod test {
             let mut sortdb = SortitionDB::connect(
                 &config.burnchain.get_db_path(),
                 config.burnchain.first_block_height,
-                &config.burnchain.first_block_hash,
-                0,
                 &epochs,
                 true,
             )

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -384,11 +384,7 @@ impl PeerNetwork {
             local_peer: local_peer,
             chain_view: chain_view,
             chain_view_stable_consensus_hash: ConsensusHash([0u8; 20]),
-            burnchain_tip: BlockSnapshot::initial(
-                first_block_height,
-                &first_burn_header_hash,
-                first_burn_header_ts as u64,
-            ),
+            burnchain_tip: BlockSnapshot::initial(first_block_height),
 
             peerdb: peerdb,
             atlasdb: atlasdb,

--- a/src/net/p2p.rs
+++ b/src/net/p2p.rs
@@ -374,8 +374,6 @@ impl PeerNetwork {
         }
 
         let first_block_height = burnchain.first_block_height;
-        let first_burn_header_hash = burnchain.first_block_hash.clone();
-        let first_burn_header_ts = burnchain.first_block_timestamp;
 
         let mut network = PeerNetwork {
             peer_version: peer_version,

--- a/testnet/stacks-node/src/burnchains/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/db_indexer.rs
@@ -235,22 +235,22 @@ impl BurnchainChannel for DBBurnBlockInputChannel {
 
         // In order to record this block, we either: 1) have already started recording, or 2) this
         // block has the "first hash" we're looking for.
-        if current_canonical_tip_opt.is_none() {
-            info!(
-                "BurnchainChannel: have not written any blocks yet";
-                "header_hash" => %header.header_hash
-            );
-            if header.header_hash != self.first_burn_header_hash {
-                info!("BurnchainChannel: not the first block we are looking for";
-                "header_hash"=> %self.first_burn_header_hash, "self.first_burn_header_hash" => %self.first_burn_header_hash);
-                return Ok(());
-            } else {
-                info!(
-                    "BurnchainChannel: wakes up after finding first header";
-                    "header_hash" => %header.header_hash
-                );
-            }
-        }
+        // if current_canonical_tip_opt.is_none() {
+        //     info!(
+        //         "BurnchainChannel: have not written any blocks yet";
+        //         "header_hash" => %header.header_hash
+        //     );
+        //     if header.header_hash != self.first_burn_header_hash {
+        //         info!("BurnchainChannel: not the first block we are looking for";
+        //         "header_hash"=> %self.first_burn_header_hash, "self.first_burn_header_hash" => %self.first_burn_header_hash);
+        //         return Ok(());
+        //     } else {
+        //         info!(
+        //             "BurnchainChannel: wakes up after finding first header";
+        //             "header_hash" => %header.header_hash
+        //         );
+        //     }
+        // }
 
         // Decide if this new node is part of the canonical chain.
         let (is_canonical, needs_reorg) = match &current_canonical_tip_opt {

--- a/testnet/stacks-node/src/burnchains/l1_events.rs
+++ b/testnet/stacks-node/src/burnchains/l1_events.rs
@@ -20,7 +20,7 @@ use stacks::clarity::vm::Value as ClarityValue;
 use stacks::codec::StacksMessageCodec;
 use stacks::core::StacksEpoch;
 use stacks::types::chainstate::{
-    BlockHeaderHash, BurnchainHeaderHash, StacksAddress, StacksBlockId,
+    BlockHeaderHash, StacksAddress, StacksBlockId,
 };
 use stacks::util::hash::hex_bytes;
 use stacks::util::sleep_ms;
@@ -29,7 +29,7 @@ use stacks::vm::ClarityName;
 
 use super::db_indexer::DBBurnchainIndexer;
 use super::{burnchain_from_config, BurnchainChannel, Error};
-use crate::config::BurnchainConfig;
+
 use crate::operations::BurnchainOpSigner;
 use crate::{BurnchainController, BurnchainTip, Config};
 

--- a/testnet/stacks-node/src/burnchains/l1_events.rs
+++ b/testnet/stacks-node/src/burnchains/l1_events.rs
@@ -424,12 +424,7 @@ impl BurnchainController for L1Controller {
         let burnchain = self.get_burnchain();
 
         self.indexer.connect(true)?;
-        burnchain.connect_db(
-            &self.indexer,
-            true,
-            self.indexer.get_first_block_header_hash()?,
-            self.indexer.get_first_block_header_timestamp()?,
-        )?;
+        burnchain.connect_db(&self.indexer, true)?;
         Ok(())
     }
 

--- a/testnet/stacks-node/src/burnchains/mock_events.rs
+++ b/testnet/stacks-node/src/burnchains/mock_events.rs
@@ -469,12 +469,7 @@ impl BurnchainController for MockController {
 
     fn connect_dbs(&mut self) -> Result<(), Error> {
         let burnchain = self.get_burnchain();
-        burnchain.connect_db(
-            &self.indexer,
-            true,
-            self.indexer.get_first_block_header_hash()?,
-            self.indexer.get_first_block_header_timestamp()?,
-        )?;
+        burnchain.connect_db(&self.indexer, true)?;
         Ok(())
     }
 

--- a/testnet/stacks-node/src/burnchains/mod.rs
+++ b/testnet/stacks-node/src/burnchains/mod.rs
@@ -13,6 +13,7 @@ use stacks::burnchains::Burnchain;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::operations::BlockstackOperationType;
 use stacks::chainstate::burn::BlockSnapshot;
+use stacks::chainstate::stacks::index::ClarityMarfTrieId;
 use stacks::core::StacksEpoch;
 use stacks::types::chainstate::BurnchainHeaderHash;
 
@@ -186,14 +187,10 @@ pub fn burnchain_from_config(
     config: &BurnchainConfig,
 ) -> Result<Burnchain, burnchains::Error> {
     let mut burnchain = Burnchain::new(&burn_db_path, &config.chain, &config.mode)?;
-    burnchain.first_block_hash = BurnchainHeaderHash::from_hex(&config.first_burn_header_hash)
-        .expect(&format!(
-            "Could not parse BurnchainHeaderHash: {}",
-            &config.first_burn_header_hash
-        ));
+    burnchain.first_block_hash = BurnchainHeaderHash::sentinel();
     burnchain.first_block_height = config.first_burn_header_height;
-    burnchain.first_block_timestamp = config.first_burn_header_timestamp as u32;
+    burnchain.first_block_timestamp = 0;
 
-    info!("burnchain: {:?}", &burnchain);
+    debug!("Configured burnchain: {:?}", &burnchain);
     Ok(burnchain)
 }

--- a/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
@@ -196,7 +196,7 @@ fn test_drop_headers() {
 /// that will be the first block we record.
 #[test]
 fn test_first_header_hash_requires_waiting() {
-    let mut config = make_test_config();
+    let config = make_test_config();
 
     let mut indexer = DBBurnchainIndexer::new(&random_sortdb_test_dir(), config, true)
         .expect("Couldn't create indexer.");

--- a/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
@@ -4,7 +4,6 @@ use crate::burnchains::tests::{make_test_new_block, random_sortdb_test_dir};
 use crate::config::BurnchainConfig;
 use stacks::burnchains::indexer::BurnchainIndexer;
 use stacks::chainstate::coordinator::CoordinatorCommunication;
-use stacks::types::chainstate::{BurnchainHeaderHash, StacksBlockId};
 
 /// Create config settings for the tests.
 fn make_test_config() -> BurnchainConfig {
@@ -12,9 +11,6 @@ fn make_test_config() -> BurnchainConfig {
     config.chain = "stacks_layer_1".to_string();
     config.mode = "hyperchain".to_string();
     config.first_burn_header_height = 1;
-    config.first_burn_header_hash =
-        "0101010101010101010101010101010101010101010101010101010101010101".to_string();
-    config.first_burn_header_timestamp = 0u64;
     config
 }
 
@@ -202,8 +198,6 @@ fn test_drop_headers() {
 fn test_first_header_hash_requires_waiting() {
     let mut config = make_test_config();
 
-    config.first_burn_header_hash =
-        "0303030303030303030303030303030303030303030303030303030303030303".to_string();
     let mut indexer = DBBurnchainIndexer::new(&random_sortdb_test_dir(), config, true)
         .expect("Couldn't create indexer.");
 

--- a/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
+++ b/testnet/stacks-node/src/burnchains/tests/db_indexer.rs
@@ -237,21 +237,10 @@ fn test_db_sync_with_indexer() {
     let config = make_test_config();
     let burnchain_dir = random_sortdb_test_dir();
 
-    let first_burn_header_hash = BurnchainHeaderHash(
-        StacksBlockId::from_hex(&config.first_burn_header_hash)
-            .expect("Could not parse `first_burn_header_hash`.")
-            .0,
-    );
-
     let mut burnchain =
         burnchain_from_config(&burnchain_dir, &config).expect("Could not create Burnchain.");
     let _ = burnchain
-        .connect_db(
-            &indexer,
-            true,
-            first_burn_header_hash,
-            config.first_burn_header_timestamp,
-        )
+        .connect_db(&indexer, true)
         .expect("Could not connect burnchain.");
 
     let (_receivers, channels) = CoordinatorCommunication::instantiate();
@@ -298,21 +287,10 @@ fn test_db_sync_with_indexer_short_sequence() {
     let config = make_test_config();
     let burnchain_dir = random_sortdb_test_dir();
 
-    let first_burn_header_hash = BurnchainHeaderHash(
-        StacksBlockId::from_hex(&config.first_burn_header_hash)
-            .expect("Could not parse `first_burn_header_hash`.")
-            .0,
-    );
-
     let mut burnchain =
         burnchain_from_config(&burnchain_dir, &config).expect("Could not create Burnchain.");
     let (_sortition_db, burn_db) = burnchain
-        .connect_db(
-            &indexer,
-            true,
-            first_burn_header_hash,
-            config.first_burn_header_timestamp,
-        )
+        .connect_db(&indexer, true)
         .expect("Could not connect burnchain.");
 
     let (_receivers, channels) = CoordinatorCommunication::instantiate();
@@ -396,21 +374,10 @@ fn test_db_sync_with_indexer_long_fork_repeated_calls() {
     let config = make_test_config();
     let burnchain_dir = random_sortdb_test_dir();
 
-    let first_burn_header_hash = BurnchainHeaderHash(
-        StacksBlockId::from_hex(&config.first_burn_header_hash)
-            .expect("Could not parse `first_burn_header_hash`.")
-            .0,
-    );
-
     let mut burnchain =
         burnchain_from_config(&burnchain_dir, &config).expect("Could not create Burnchain.");
     let (_sortition_db, burn_db) = burnchain
-        .connect_db(
-            &indexer,
-            true,
-            first_burn_header_hash,
-            config.first_burn_header_timestamp,
-        )
+        .connect_db(&indexer, true)
         .expect("Could not connect burnchain.");
 
     let (_receivers, channels) = CoordinatorCommunication::instantiate();
@@ -480,21 +447,10 @@ fn test_db_sync_with_indexer_long_fork_call_at_end() {
     let config = make_test_config();
     let burnchain_dir = random_sortdb_test_dir();
 
-    let first_burn_header_hash = BurnchainHeaderHash(
-        StacksBlockId::from_hex(&config.first_burn_header_hash)
-            .expect("Could not parse `first_burn_header_hash`.")
-            .0,
-    );
-
     let mut burnchain =
         burnchain_from_config(&burnchain_dir, &config).expect("Could not create Burnchain.");
     let (_sortition_db, burn_db) = burnchain
-        .connect_db(
-            &indexer,
-            true,
-            first_burn_header_hash,
-            config.first_burn_header_timestamp,
-        )
+        .connect_db(&indexer, true)
         .expect("Could not connect burnchain.");
 
     let (_receivers, channels) = CoordinatorCommunication::instantiate();

--- a/testnet/stacks-node/src/config.rs
+++ b/testnet/stacks-node/src/config.rs
@@ -522,9 +522,6 @@ impl Config {
                             .expect("Hyperchain nodes must configure L1 contract identifier"),
                     )
                     .expect("Invalid contract identifier configured with hyperchain node"),
-                    first_burn_header_hash: burnchain
-                        .first_burn_header_hash
-                        .unwrap_or(default_burnchain_config.first_burn_header_hash),
                     first_burn_header_height: burnchain
                         .first_burn_header_height
                         .unwrap_or(default_burnchain_config.first_burn_header_height),
@@ -984,11 +981,6 @@ pub struct BurnchainConfig {
     pub epochs: Option<Vec<StacksEpoch>>,
     /// The layer 1 contract that the hyperchain will watch for Stacks events.
     pub contract_identifier: QualifiedContractIdentifier,
-    /// Hash of the first L1 Stacks block that we are going to index. The L2 indexer
-    /// will follow all decendents of this.
-    pub first_burn_header_hash: String,
-    /// Time stamp for the first header we are looking for.
-    pub first_burn_header_timestamp: u64,
     /// Block height for the first header.
     pub first_burn_header_height: u64,
     /// The anchor mode for any transactions submitted to L1
@@ -1023,9 +1015,7 @@ impl Default for BurnchainConfig {
             rbf_fee_increment: DEFAULT_RBF_FEE_RATE_INCREMENT,
             epochs: None,
             contract_identifier: QualifiedContractIdentifier::transient(),
-            first_burn_header_hash: "".to_string(),
             first_burn_header_height: 0u64,
-            first_burn_header_timestamp: 0u64,
             anchor_mode: TransactionAnchorMode::Any,
         }
     }
@@ -1084,7 +1074,6 @@ pub struct BurnchainConfigFile {
     pub max_rbf: Option<u64>,
     pub epochs: Option<Vec<StacksEpoch>>,
     pub contract_identifier: Option<String>,
-    pub first_burn_header_hash: Option<String>,
     pub first_burn_header_height: Option<u64>,
 }
 

--- a/testnet/stacks-node/src/neon_node.rs
+++ b/testnet/stacks-node/src/neon_node.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use std::{thread, thread::JoinHandle};
 
 use crate::burnchains::BurnchainController;
-use stacks::burnchains::{Burnchain, BurnchainParameters, Txid};
+use stacks::burnchains::{BurnchainParameters, Txid};
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::burn::operations::{BlockstackOperationType, LeaderBlockCommitOp};
 use stacks::chainstate::burn::BlockSnapshot;

--- a/testnet/stacks-node/src/tests/forking.rs
+++ b/testnet/stacks-node/src/tests/forking.rs
@@ -82,8 +82,6 @@ fn make_sortition_db_for_fork_tests() -> SortitionDB {
     let mut db = SortitionDB::connect(
         &random_sortdb_test_dir(),
         1,
-        &BurnchainHeaderHash([5; 32]),
-        get_epoch_time_secs(),
         &[StacksEpoch {
             epoch_id: StacksEpochId::Epoch10,
             start_height: 0,

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -7,26 +7,26 @@ use crate::neon;
 use crate::tests::neon_integrations::{get_account, submit_tx, test_observer};
 use crate::tests::{make_contract_call, make_contract_publish, to_addr};
 use clarity::types::chainstate::StacksAddress;
-use clarity::util::get_epoch_time_secs;
+
 use clarity::vm::database::ClaritySerializable;
 use clarity::vm::representations::ContractName;
 use clarity::vm::types::PrincipalData;
 use clarity::vm::Value;
-use reqwest::Response;
+
 use stacks::burnchains::Burnchain;
 use stacks::chainstate::burn::db::sortdb::SortitionDB;
 use stacks::chainstate::stacks::{StacksPrivateKey, StacksTransaction, TransactionPayload};
 use stacks::codec::StacksMessageCodec;
 use stacks::net::CallReadOnlyRequestBody;
-use stacks::net::RPCPeerInfoData;
+
 use stacks::util::hash::hex_bytes;
 use stacks::vm::types::QualifiedContractIdentifier;
 use stacks::vm::ClarityName;
 use std::convert::{TryFrom, TryInto};
 use std::env;
 use std::io::{BufRead, BufReader};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{Ordering};
+
 use std::time::{Duration, Instant};
 
 #[derive(std::fmt::Debug)]
@@ -778,7 +778,7 @@ fn l1_deposit_stx_integration_test() {
     config.node.p2p_bind = "127.0.0.1:30444".into();
     let l2_rpc_origin = format!("http://{}", &config.node.rpc_bind);
 
-    let mut l2_nonce = 0;
+    let _l2_nonce = 0;
 
     config.burnchain.contract_identifier =
         QualifiedContractIdentifier::new(user_addr.into(), "hyperchain-controller".into());

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -232,8 +232,6 @@ fn l1_basic_listener_test() {
 
     // Start the L2 run loop.
     let mut config = super::new_test_conf();
-    config.burnchain.first_burn_header_hash =
-        "9946c68526249c259231f1660be4c72e915ebe1f25a8c8400095812b487eb279".to_string();
     config.burnchain.first_burn_header_height = 1;
     config.burnchain.chain = "stacks_layer_1".to_string();
     config.burnchain.mode = "hyperchain".to_string();
@@ -296,8 +294,6 @@ fn l1_integration_test() {
     config.node.mining_key = Some(MOCKNET_PRIVATE_KEY_2.clone());
     let miner_account = to_addr(&MOCKNET_PRIVATE_KEY_2);
 
-    config.burnchain.first_burn_header_hash =
-        "9946c68526249c259231f1660be4c72e915ebe1f25a8c8400095812b487eb279".to_string();
     config.burnchain.first_burn_header_height = 1;
     config.burnchain.chain = "stacks_layer_1".to_string();
     config.burnchain.mode = "hyperchain".to_string();
@@ -431,8 +427,6 @@ fn l1_deposit_asset_integration_test() {
     config.add_initial_balance(user_addr.to_string(), 10000000);
     config.add_initial_balance(miner_account.to_string(), 10000000);
 
-    config.burnchain.first_burn_header_hash =
-        "9946c68526249c259231f1660be4c72e915ebe1f25a8c8400095812b487eb279".to_string();
     config.burnchain.first_burn_header_height = 1;
     config.burnchain.chain = "stacks_layer_1".to_string();
     config.burnchain.mode = "hyperchain".to_string();
@@ -773,8 +767,6 @@ fn l1_deposit_stx_integration_test() {
     config.add_initial_balance(user_addr.to_string(), 10000000);
     config.add_initial_balance(miner_account.to_string(), 10000000);
 
-    config.burnchain.first_burn_header_hash =
-        "9946c68526249c259231f1660be4c72e915ebe1f25a8c8400095812b487eb279".to_string();
     config.burnchain.first_burn_header_height = 1;
     config.burnchain.chain = "stacks_layer_1".to_string();
     config.burnchain.mode = "hyperchain".to_string();
@@ -939,8 +931,6 @@ fn l2_simple_contract_calls() {
     let mut config = super::new_test_conf();
     config.node.mining_key = Some(MOCKNET_PRIVATE_KEY_2.clone());
 
-    config.burnchain.first_burn_header_hash =
-        "9946c68526249c259231f1660be4c72e915ebe1f25a8c8400095812b487eb279".to_string();
     config.burnchain.first_burn_header_height = 1;
     config.burnchain.chain = "stacks_layer_1".to_string();
     config.burnchain.mode = "hyperchain".to_string();

--- a/testnet/stacks-node/src/tests/l1_observer_test.rs
+++ b/testnet/stacks-node/src/tests/l1_observer_test.rs
@@ -331,7 +331,7 @@ fn l1_integration_test() {
     .unwrap();
     let (sortition_db, burndb) = burnchain.open_db(true).unwrap();
 
-    let mut stacks_l1_controller = StacksL1Controller::new(l1_toml_file.to_string(), true);
+    let mut stacks_l1_controller = StacksL1Controller::new(l1_toml_file.to_string(), false);
     let _stacks_res = stacks_l1_controller
         .start_process()
         .expect("stacks l1 controller didn't start");

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -579,12 +579,12 @@ fn mockstack_integration_test() {
 #[ignore]
 fn mockstack_wait_for_first_block() {
     reset_static_burnblock_simulator_channel();
-    let (mut conf, miner_account) = mockstack_test_conf();
+    let (mut conf, _miner_account) = mockstack_test_conf();
     let prom_bind = format!("{}:{}", "127.0.0.1", 6000);
     conf.node.prometheus_bind = Some(prom_bind.clone());
     conf.burnchain.first_burn_header_height = 16;
 
-    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+    let _http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     let mut run_loop = neon::RunLoop::new(conf.clone());
     let blocks_processed = run_loop.get_blocks_processed_arc();
@@ -606,7 +606,7 @@ fn mockstack_wait_for_first_block() {
 
     // Walk up 16 + 1 blocks.
     btc_regtest_controller.next_block(None);
-    for i in 0..16 {
+    for _i in 0..16 {
         btc_regtest_controller.next_block(None);
     }
 
@@ -893,7 +893,7 @@ fn faucet_test() {
 fn no_contract_calls_forking_integration_test() {
     reset_static_burnblock_simulator_channel();
 
-    let (mut conf, miner_account) = mockstack_test_conf();
+    let (mut conf, _miner_account) = mockstack_test_conf();
     let prom_bind = format!("{}:{}", "127.0.0.1", 6000);
     conf.node.prometheus_bind = Some(prom_bind.clone());
     conf.node.miner = true;
@@ -902,7 +902,7 @@ fn no_contract_calls_forking_integration_test() {
     conf.add_initial_balance(user_addr.to_string(), 10000000);
 
     test_observer::spawn();
-    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+    let _http_origin = format!("http://{}", &conf.node.rpc_bind);
 
     let burnchain = Burnchain::new(
         &conf.get_burn_db_path(),
@@ -915,7 +915,7 @@ fn no_contract_calls_forking_integration_test() {
     let blocks_processed = run_loop.get_blocks_processed_arc();
 
     let channel = run_loop.get_coordinator_channel().unwrap();
-    let l2_rpc_origin = format!("http://{}", &conf.node.rpc_bind);
+    let _l2_rpc_origin = format!("http://{}", &conf.node.rpc_bind);
 
     let mut btc_regtest_controller = MockController::new(conf, channel.clone());
 
@@ -964,7 +964,7 @@ fn no_contract_calls_forking_integration_test() {
     }
 
     let mut cursor = common_ancestor;
-    for i in 0..3 {
+    for _i in 0..3 {
         cursor = btc_regtest_controller.next_block(Some(cursor));
     }
 

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -25,8 +25,7 @@ use crate::tests::l1_observer_test::MOCKNET_PRIVATE_KEY_1;
 use crate::tests::{
     make_contract_call, make_contract_publish, make_stacks_transfer, to_addr, SK_1, SK_2, SK_3,
 };
-use crate::{Config, ConfigFile, Keychain};
-use std::convert::TryInto;
+use crate::{Config, Keychain};
 
 pub fn mockstack_test_conf() -> (Config, StacksAddress) {
     let mut conf = super::new_test_conf();
@@ -53,8 +52,6 @@ pub fn mockstack_test_conf() -> (Config, StacksAddress) {
     conf.miner.first_attempt_time_ms = i64::max_value() as u64;
     conf.miner.subsequent_attempt_time_ms = i64::max_value() as u64;
 
-    conf.burnchain.first_burn_header_hash =
-        "0000000000000000000000000000000000000000000000000000000000000001".to_string();
     conf.burnchain.first_burn_header_height = 1;
 
     let miner_account = keychain.origin_address(conf.is_mainnet()).unwrap();
@@ -585,8 +582,6 @@ fn mockstack_wait_for_first_block() {
     let (mut conf, miner_account) = mockstack_test_conf();
     let prom_bind = format!("{}:{}", "127.0.0.1", 6000);
     conf.node.prometheus_bind = Some(prom_bind.clone());
-    conf.burnchain.first_burn_header_hash =
-        "0000000000000000000000000000000000000000000000000000000000000010".to_string();
     conf.burnchain.first_burn_header_height = 16;
 
     let http_origin = format!("http://{}", &conf.node.rpc_bind);


### PR DESCRIPTION
This PR implements #98: removing the requirement for configuring a "first burn hash."

This was previously required so that the initial trie in the sortition database's MARF would have a burn header hash that subsequent tries would naturally use as a parent (because the "burn header hash" of that initial trie would be the subsequent tries actual parent).

This PR changes the behavior of the sortition database such that this isn't required: burn blocks whose height is "first_burn_height + 1" have their parent trie explicitly set to the initial trie. This initial trie just uses the sentinel / all-zeros as its burn header hash. This complicates a couple different areas of the codebase: anywhere where the Sortition MARF is "walked backwards" using the parent burn header hash needs to check if the parent should be the initial burn block or not.

