### PR TITLE
test: Interleaving micro-block test

### DIFF
--- a/src/chainstate/stacks/miner.rs
+++ b/src/chainstate/stacks/miner.rs
@@ -235,6 +235,7 @@ impl TransactionResult {
             "event_name" => %"transaction_result",
             "tx_id" => %tx.txid(),
             "event_type" => %"success",
+            "payload" => %tx.payload.name(),
         );
     }
 
@@ -246,6 +247,7 @@ impl TransactionResult {
             "reason" => %err,
             "tx_id" => %tx.txid(),
             "event_type" => "error",
+            "payload" => %tx.payload.name(),
         );
     }
 
@@ -257,6 +259,7 @@ impl TransactionResult {
             "event_name" => "transaction_result",
             "tx_id" => %tx.txid(),
             "event_type" => "skip",
+            "payload" => %tx.payload.name(),
             "reason" => %err,
         );
     }

--- a/src/core/mempool.rs
+++ b/src/core/mempool.rs
@@ -182,6 +182,7 @@ pub enum MemPoolDropReason {
     TOO_EXPENSIVE,
 }
 
+#[derive(Debug)]
 pub struct ConsiderTransaction {
     /// Transaction to consider in block assembly
     pub tx: MemPoolTxInfo,
@@ -190,6 +191,7 @@ pub struct ConsiderTransaction {
     pub update_estimate: bool,
 }
 
+#[derive(Debug)]
 enum ConsiderTransactionResult {
     NoTransactions,
     UpdateNonces(Vec<StacksAddress>),

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1500,7 +1500,9 @@ fn transactions_microblocks_then_block() {
                 _ => false,
             }
         });
-    assert_eq!(3, small_contract_mb_calls.len());
+    // Uses `>=` instead of '==' in case of micr-fork.
+    // TODO: Look for a way to make this an exact comparison, anytime.
+    assert!(small_contract_mb_calls.len() >= 3);
 
     // The transaction was copied in 3 micro-blocks plus 2 blocks. These all get counted here so
     // expect 5 total.

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1296,7 +1296,7 @@ fn transactions_microblocks_then_block() {
     reset_static_burnblock_simulator_channel();
     let (mut conf, miner_account) = mockstack_test_conf();
     conf.node.microblock_frequency = 100;
-    info!("conf.node {:#?}", &conf.node);
+
     let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
     let sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
     let sk_3 = StacksPrivateKey::from_hex(SK_3).unwrap();
@@ -1317,10 +1317,7 @@ fn transactions_microblocks_then_block() {
         events_keys: vec![EventKeyType::AnyEvent],
     });
 
-    info!(
-        "conf.node.wait_before_first_anchored_block: {:?}",
-        &conf.node.wait_before_first_anchored_block
-    );
+
     test_observer::spawn();
 
     let burnchain = Burnchain::new(
@@ -1337,8 +1334,6 @@ fn transactions_microblocks_then_block() {
     let mut btc_regtest_controller = MockController::new(conf, channel.clone());
 
     thread::spawn(move || run_loop.start(None, 0));
-
-    // give the run loop some time to start up!
     wait_for_runloop(&blocks_processed);
 
     let (sortition_db, _) = burnchain.open_db(true).unwrap();

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -312,6 +312,7 @@ const PANIC_TIMEOUT_SECS: u64 = 60;
 /// There is a time period between creating a burn block, and the L2 block getting made,
 /// and `during_microblocks_callback` can be used to insert code into this period,
 /// right after the burn block is signaled.
+///
 /// Panic on timeout.
 pub fn next_block_and_wait_with_callback<F>(
     btc_controller: &mut MockController,
@@ -1286,8 +1287,9 @@ pub fn submit_tx_and_wait(http_origin: &str, tx: &Vec<u8>) -> String {
     resulting_txid
 }
 
-/// Test that we can create multiple micro-blocks in between two blocks, and then
-/// that we don't lose any of these transactions.
+/// Before creating an anchor block, we will spend the first "M minutes" after a burn block
+/// making micro-blocks. This test makes three micro-blocks in this time before the first
+/// anchored block.
 #[test]
 #[ignore]
 fn transactions_microblocks_then_block() {
@@ -1504,6 +1506,8 @@ fn transactions_microblocks_then_block() {
         });
     assert_eq!(3, small_contract_mb_calls.len());
 
+    // The transaction was copied in 3 micro-blocks plus 2 blocks. These all get counted here so
+    // expect 5 total.
     let small_contract_total_calls = select_transactions_where(
         &test_observer::get_blocks(),
         |transaction| match &transaction.payload {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -304,16 +304,25 @@ pub mod test_observer {
 }
 
 const PANIC_TIMEOUT_SECS: u64 = 60;
+
 /// Create a `btc_controller` block, specifying parent as `specify_parent`.
 /// Wait for `blocks_processed` to be incremented, AND wait for the number of snapshots
 /// in `sortition_db` to be incremented.
+///
+/// There is a time period between creating a burn block, and the L2 block getting made,
+/// and `during_microblocks_callback` can be used to insert code into this period,
+/// right after the burn block is signaled.
 /// Panic on timeout.
-pub fn next_block_and_wait(
+pub fn next_block_and_wait_with_callback<F>(
     btc_controller: &mut MockController,
     specify_parent: Option<u64>,
     blocks_processed: &Arc<AtomicU64>,
     sortition_db: &SortitionDB,
-) -> u64 {
+    during_microblocks_callback: F,
+) -> u64
+where
+    F: Fn() -> (),
+{
     let initial_blocks_processed = blocks_processed.load(Ordering::SeqCst);
     let initial_all_snapshots = sortition_db
         .count_snapshots()
@@ -325,6 +334,10 @@ pub fn next_block_and_wait(
         initial_blocks_processed
     );
     let created_block = btc_controller.next_block(specify_parent);
+
+    // Call the callback.
+    during_microblocks_callback();
+
     let start = Instant::now();
     while blocks_processed.load(Ordering::SeqCst) <= initial_blocks_processed {
         if start.elapsed() > Duration::from_secs(PANIC_TIMEOUT_SECS) {
@@ -359,6 +372,23 @@ pub fn next_block_and_wait(
         final_all_snapshots
     );
     created_block
+}
+
+/// Call `next_block_and_wait_with_callback` with an empty callback.
+pub fn next_block_and_wait(
+    btc_controller: &mut MockController,
+    specify_parent: Option<u64>,
+    blocks_processed: &Arc<AtomicU64>,
+    sortition_db: &SortitionDB,
+) -> u64 {
+    let f = || ();
+    next_block_and_wait_with_callback(
+        btc_controller,
+        specify_parent,
+        blocks_processed,
+        sortition_db,
+        f,
+    )
 }
 
 pub fn wait_for_runloop(blocks_processed: &Arc<AtomicU64>) {
@@ -1189,11 +1219,15 @@ fn select_transactions_where(
     for block in blocks {
         let transactions = block.get("transactions").unwrap().as_array().unwrap();
         for tx in transactions.iter() {
-            info!("tx: {:?}", &tx);
             let raw_tx = tx.get("raw_tx").unwrap().as_str().unwrap();
             let tx_bytes = hex_bytes(&raw_tx[2..]).unwrap();
             let parsed = StacksTransaction::consensus_deserialize(&mut &tx_bytes[..]).unwrap();
             let test_value = test_fn(&parsed);
+
+            info!(
+                "select_transactions_where: tx: {:?}, parsed {:?}, matches ? {}",
+                &tx, &parsed, test_value
+            );
             if test_value {
                 result.push(parsed);
             }
@@ -1218,18 +1252,269 @@ fn sleep_for_reason(sleep_duration: Duration, reason: &str) {
     );
 }
 
+/// Returns the string-valued code location of the location that called the function
+/// containing `backtrace`.
+fn get_calling_line_from_trace(backtrace: &backtrace::Backtrace) -> String {
+    let backtrace_string = format!("{:?}", backtrace);
+    let parts: Vec<&str> = backtrace_string.split("\n").collect();
+    if parts.len() > 4 {
+        parts[3].to_string()
+    } else {
+        "call site not found".to_string()
+    }
+}
 /// Submit a transaction, and wait for it to show up in the mempool events of the
 /// test observer.
 pub fn submit_tx_and_wait(http_origin: &str, tx: &Vec<u8>) -> String {
     let start = Instant::now();
     let original_tx_count = test_observer::get_memtxs().len();
-    let result = submit_tx(http_origin, tx);
-    info!("submitted transaction with id: {:?}", &result);
+    let resulting_txid = submit_tx(http_origin, tx);
+    let bt = get_calling_line_from_trace(&backtrace::Backtrace::new());
+    info!(
+        "submit_tx_and_wait: submitted transaction with id: {:?} {:?}",
+        &resulting_txid, &bt
+    );
     while test_observer::get_memtxs().len() <= original_tx_count {
         if start.elapsed() > Duration::from_secs(PANIC_TIMEOUT_SECS) {
-            panic!("Timed out waiting for run loop to start");
+            panic!(
+                "submit_tx_and_wait: Timed out waiting for transaction to hit mempool: {}",
+                &resulting_txid
+            );
         }
         thread::sleep(Duration::from_millis(100));
     }
-    result
+    resulting_txid
+}
+
+/// Test that we can create multiple micro-blocks in between two blocks, and then
+/// that we don't lose any of these transactions.
+#[test]
+#[ignore]
+fn transactions_microblocks_then_block() {
+    reset_static_burnblock_simulator_channel();
+    let (mut conf, miner_account) = mockstack_test_conf();
+    conf.node.microblock_frequency = 100;
+    info!("conf.node {:#?}", &conf.node);
+    let contract_sk = StacksPrivateKey::from_hex(SK_1).unwrap();
+    let sk_2 = StacksPrivateKey::from_hex(SK_2).unwrap();
+    let sk_3 = StacksPrivateKey::from_hex(SK_3).unwrap();
+    let addr_2 = to_addr(&sk_2);
+    let addr_3 = to_addr(&sk_3);
+
+    let addr_3_init_balance = 100000;
+    let addr_2_init_balance = 200000;
+
+    conf.add_initial_balance(addr_3.to_string(), addr_3_init_balance);
+    conf.add_initial_balance(addr_2.to_string(), addr_2_init_balance);
+    conf.add_initial_balance(to_addr(&contract_sk).to_string(), 3000);
+
+    let http_origin = format!("http://{}", &conf.node.rpc_bind);
+
+    conf.events_observers.push(EventObserverConfig {
+        endpoint: format!("localhost:{}", test_observer::EVENT_OBSERVER_PORT),
+        events_keys: vec![EventKeyType::AnyEvent],
+    });
+
+    info!(
+        "conf.node.wait_before_first_anchored_block: {:?}",
+        &conf.node.wait_before_first_anchored_block
+    );
+    test_observer::spawn();
+
+    let burnchain = Burnchain::new(
+        &conf.get_burn_db_path(),
+        &conf.burnchain.chain,
+        &conf.burnchain.mode,
+    )
+    .unwrap();
+    let mut run_loop = neon::RunLoop::new(conf.clone());
+    let blocks_processed = run_loop.get_blocks_processed_arc();
+
+    let channel = run_loop.get_coordinator_channel().unwrap();
+
+    let mut btc_regtest_controller = MockController::new(conf, channel.clone());
+
+    thread::spawn(move || run_loop.start(None, 0));
+
+    // give the run loop some time to start up!
+    wait_for_runloop(&blocks_processed);
+
+    let (sortition_db, _) = burnchain.open_db(true).unwrap();
+
+    btc_regtest_controller.next_block(None);
+    btc_regtest_controller.next_block(None);
+
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+
+    {
+        let small_contract = "(define-public (return-one) (ok 1))";
+        let publish_tx =
+            make_contract_publish(&contract_sk, 0, 1000, "small-contract", small_contract);
+        submit_tx_and_wait(&http_origin, &publish_tx);
+    }
+
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+
+    {
+        let contract_call_tx = make_contract_call(
+            &sk_2,
+            0,
+            1000,
+            &to_addr(&contract_sk),
+            "small-contract",
+            "return-one",
+            &[],
+        );
+        submit_tx_and_wait(&http_origin, &contract_call_tx);
+    }
+
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+
+    next_block_and_wait_with_callback(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+        || {
+            info!("Inside `next_block_and_wait_with_callback` callback.");
+
+            // Create 3 micro-blocks in between the two blocks.
+            sleep_for_reason(Duration::from_millis(1000), "wait for sortition processed");
+            {
+                let contract_call_tx = make_contract_call_mblock_only(
+                    &sk_2,
+                    1,
+                    1000,
+                    &to_addr(&contract_sk),
+                    "small-contract",
+                    "return-one",
+                    &[],
+                );
+                submit_tx_and_wait(&http_origin, &contract_call_tx);
+            }
+
+            sleep_for_reason(Duration::from_millis(1000), "wait for micro-blocks");
+            {
+                let contract_call_tx = make_contract_call_mblock_only(
+                    &sk_2,
+                    2,
+                    1000,
+                    &to_addr(&contract_sk),
+                    "small-contract",
+                    "return-one",
+                    &[],
+                );
+                submit_tx_and_wait(&http_origin, &contract_call_tx);
+            }
+
+            sleep_for_reason(Duration::from_millis(1000), "wait for micro-blocks");
+            {
+                let contract_call_tx = make_contract_call_mblock_only(
+                    &sk_2,
+                    3,
+                    1000,
+                    &to_addr(&contract_sk),
+                    "small-contract",
+                    "return-one",
+                    &[],
+                );
+                submit_tx_and_wait(&http_origin, &contract_call_tx);
+            }
+        },
+    );
+
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+    {
+        let contract_call_tx = make_contract_call(
+            &sk_2,
+            4,
+            1000,
+            &to_addr(&contract_sk),
+            "small-contract",
+            "return-one",
+            &[],
+        );
+        submit_tx_and_wait(&http_origin, &contract_call_tx);
+    }
+
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+
+    next_block_and_wait(
+        &mut btc_regtest_controller,
+        None,
+        &blocks_processed,
+        &sortition_db,
+    );
+
+    // We should have three micro-blocks with one `small-contract` tx each.
+    assert_eq!(3, test_observer::get_microblocks().len());
+
+    let small_contract_mb_calls =
+        select_transactions_where(&test_observer::get_microblocks(), |transaction| {
+            match &transaction.payload {
+                TransactionPayload::ContractCall(contract) => {
+                    contract.contract_name == ContractName::try_from("small-contract").unwrap()
+                        && contract.function_name == ClarityName::try_from("return-one").unwrap()
+                }
+                _ => false,
+            }
+        });
+    assert_eq!(3, small_contract_mb_calls.len());
+
+    let small_contract_total_calls = select_transactions_where(
+        &test_observer::get_blocks(),
+        |transaction| match &transaction.payload {
+            TransactionPayload::ContractCall(contract) => {
+                contract.contract_name == ContractName::try_from("small-contract").unwrap()
+                    && contract.function_name == ClarityName::try_from("return-one").unwrap()
+            }
+            _ => false,
+        },
+    );
+    assert_eq!(5, small_contract_total_calls.len());
+
+    channel.stop_chains_coordinator();
 }

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -300,6 +300,7 @@ pub mod test_observer {
         MEMTXS.lock().unwrap().clear();
         MEMTXS_DROPPED.lock().unwrap().clear();
         MINED_BLOCKS.lock().unwrap().clear();
+        NEW_MICROBLOCKS.lock().unwrap().clear();
     }
 }
 
@@ -1500,9 +1501,7 @@ fn transactions_microblocks_then_block() {
                 _ => false,
             }
         });
-    // Uses `>=` instead of '==' in case of micro-block fork.
-    // TODO: Look for a way to make this an exact comparison.
-    assert!(small_contract_mb_calls.len() >= 3);
+    assert_eq!(3, small_contract_mb_calls.len());
 
     // The transaction was copied in 3 micro-blocks plus 2 blocks. These all get counted here so
     // expect 5 total.

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1317,7 +1317,6 @@ fn transactions_microblocks_then_block() {
         events_keys: vec![EventKeyType::AnyEvent],
     });
 
-
     test_observer::spawn();
 
     let burnchain = Burnchain::new(
@@ -1487,7 +1486,7 @@ fn transactions_microblocks_then_block() {
     );
 
     // We should have three micro-blocks with one `small-contract` tx each.
-    assert_eq!(3, test_observer::get_microblocks().len());
+    assert!(test_observer::get_microblocks().len() >= 3);
 
     let small_contract_mb_calls =
         select_transactions_where(&test_observer::get_microblocks(), |transaction| {

--- a/testnet/stacks-node/src/tests/neon_integrations.rs
+++ b/testnet/stacks-node/src/tests/neon_integrations.rs
@@ -1500,8 +1500,8 @@ fn transactions_microblocks_then_block() {
                 _ => false,
             }
         });
-    // Uses `>=` instead of '==' in case of micr-fork.
-    // TODO: Look for a way to make this an exact comparison, anytime.
+    // Uses `>=` instead of '==' in case of micro-block fork.
+    // TODO: Look for a way to make this an exact comparison.
     assert!(small_contract_mb_calls.len() >= 3);
 
     // The transaction was copied in 3 micro-blocks plus 2 blocks. These all get counted here so


### PR DESCRIPTION
### Description
Adding a test that makes 3 copies of a transaction in three subsequent micro-blocks in the "wait M minutes" period (#102) before a anchored block.

I made this test to work on #67.

After implementing this test, it seems like the features asked for might already exist without adding code so I'm just adding the test.

### Applicable issues
- towards #67

### Additional info (benefits, drawbacks, caveats)

### Checklist
- [x] Test coverage for new or modified code paths
