### PR TITLE
Do not rebuild for changes to docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
     paths-ignore:
       - '**/CHANGELOG.md'
       - '**/.releaserc'
+      - 'docs/**'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
[[Related Issue]](https://github.com/hirosystems/devops/issues/1261)

This commit will skip rebuilding subnets if there are any changes within the `docs` directory.